### PR TITLE
feat: support standard frontmatter and plain markdown formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,10 @@ slug: my-post
 meta_title: SEO Title
 meta_description: A short description
 excerpt: Custom excerpt
-tags: [dev, ghost]
+tags: [dev, ghost]   # or block sequence:
+# tags:
+#   - dev
+#   - ghost
 ---
 
 # My Blog Post

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Create, edit, publish, and sync blog posts directly from Claude Code, Cursor, or
 ## Quick Start
 
 ```bash
-git clone https://github.com/your-username/ghost-mcp.git
+git clone https://github.com/uppinote20/ghost-mcp.git
 cd ghost-mcp
 npm install
 npm run build
@@ -92,6 +92,38 @@ If you prefer to configure manually, add to your MCP settings:
 | `ghost_analyze_tags` | Find unused, low-use, and similar tags |
 | `ghost_push_local` | Push a local markdown file to Ghost as a draft |
 | `ghost_sync_status` | Compare local files with Ghost posts |
+
+## Markdown Formats for `ghost_push_local`
+
+Three formats are auto-detected:
+
+**1. YAML Frontmatter (recommended)**
+
+```markdown
+---
+slug: my-post
+meta_title: SEO Title
+meta_description: A short description
+excerpt: Custom excerpt
+tags: [dev, ghost]
+---
+
+# My Blog Post
+
+Content here...
+```
+
+**2. Plain Markdown**
+
+```markdown
+# My Blog Post
+
+Content here — no metadata, Ghost auto-generates the slug.
+```
+
+**3. Legacy Markers** (internal)
+
+Uses `<!-- 본문 시작 -->` / `<!-- MCP 파싱 마커 -->` HTML comment markers with an SEO table.
 
 ## Security
 

--- a/src/parsers/markdown-parser.test.ts
+++ b/src/parsers/markdown-parser.test.ts
@@ -69,7 +69,7 @@ Body without heading.
     expect(result.body).toBe('Body without heading.');
   });
 
-  it('heading title overrides frontmatter title', () => {
+  it('frontmatter title takes priority over heading', () => {
     const md = `---
 title: Frontmatter Title
 ---
@@ -78,12 +78,9 @@ title: Frontmatter Title
 
 Body here.
 `;
-    // First # heading found in body, so frontmatter title is fallback
-    // Actually the code checks meta.title || heading, but heading is found
-    // Let's verify the behavior
     const result = parseBlogMarkdown(md);
-    // Title from frontmatter is used only when no heading exists
-    expect(result.title).toBeTruthy();
+    expect(result.title).toBe('Frontmatter Title');
+    expect(result.body).toBe('Body here.');
   });
 
   it('handles empty frontmatter values', () => {
@@ -126,6 +123,36 @@ tags: dev, ghost, mcp
 Body.
 `;
     expect(parseBlogMarkdown(md).tags).toEqual(['dev', 'ghost', 'mcp']);
+  });
+
+  it('handles YAML block sequence tags', () => {
+    const md = `---
+tags:
+  - dev
+  - ghost
+  - mcp
+---
+
+# Title
+
+Body.
+`;
+    expect(parseBlogMarkdown(md).tags).toEqual(['dev', 'ghost', 'mcp']);
+  });
+
+  it('handles hyphenated YAML keys', () => {
+    const md = `---
+meta-title: Hyphenated Key
+meta_description: Underscore Key
+---
+
+# Title
+
+Body.
+`;
+    const result = parseBlogMarkdown(md);
+    expect(result.metaTitle).toBe('Hyphenated Key');
+    expect(result.metaDescription).toBe('Underscore Key');
   });
 });
 

--- a/src/parsers/markdown-parser.test.ts
+++ b/src/parsers/markdown-parser.test.ts
@@ -6,119 +6,210 @@ import {
   toLexical,
 } from './markdown-parser.js';
 
-// ── parseBlogMarkdown ────────────────────────────
+// ── Standard frontmatter format ──────────────────
 
-describe('parseBlogMarkdown', () => {
-  const validMarkdown = `# My Blog Post Title
-
-**소스 프로젝트:** \`ghost-mcp\`
-**기술 스택:** TypeScript, Node.js
-**키워드:** MCP, Ghost, 블로그
-
+describe('parseBlogMarkdown — frontmatter format', () => {
+  const frontmatterMd = `---
+slug: my-post
+meta_title: SEO Title Here
+meta_description: A description for search engines
+excerpt: A short excerpt
+tags: [dev, ghost, mcp]
 ---
 
-<!-- 본문 시작 -->
+# My Blog Post
 
-This is the **body** of the blog post.
+This is the body content.
 
-It has multiple paragraphs.
-
-<!-- MCP 파싱 마커: 본문은 여기까지, 아래는 SEO 설정 -->
-
-## Ghost SEO 설정
-
-| Field | Value |
-|-------|-------|
-| Post URL | \`my-blog-post-title\` |
-| Meta title | My Blog Post - SEO Title |
-| Meta description | A description for search engines |
-| Excerpt | A short excerpt for the post |
+It has **multiple** paragraphs.
 `;
 
   it('extracts title from # heading', () => {
-    const result = parseBlogMarkdown(validMarkdown);
-    expect(result.title).toBe('My Blog Post Title');
+    expect(parseBlogMarkdown(frontmatterMd).title).toBe('My Blog Post');
   });
 
-  it('extracts body between markers', () => {
-    const result = parseBlogMarkdown(validMarkdown);
-    expect(result.body).toContain('This is the **body**');
-    expect(result.body).toContain('multiple paragraphs');
-    // Should NOT include SEO section
-    expect(result.body).not.toContain('Ghost SEO');
+  it('extracts body after title', () => {
+    const result = parseBlogMarkdown(frontmatterMd);
+    expect(result.body).toContain('This is the body content.');
+    expect(result.body).toContain('**multiple** paragraphs');
+    expect(result.body).not.toContain('slug:');
   });
 
-  it('extracts slug from Post URL', () => {
-    const result = parseBlogMarkdown(validMarkdown);
-    expect(result.slug).toBe('my-blog-post-title');
+  it('extracts slug', () => {
+    expect(parseBlogMarkdown(frontmatterMd).slug).toBe('my-post');
   });
 
-  it('extracts meta title', () => {
-    const result = parseBlogMarkdown(validMarkdown);
-    expect(result.metaTitle).toBe('My Blog Post - SEO Title');
+  it('extracts meta_title', () => {
+    expect(parseBlogMarkdown(frontmatterMd).metaTitle).toBe('SEO Title Here');
   });
 
-  it('extracts meta description', () => {
-    const result = parseBlogMarkdown(validMarkdown);
-    expect(result.metaDescription).toBe(
+  it('extracts meta_description', () => {
+    expect(parseBlogMarkdown(frontmatterMd).metaDescription).toBe(
       'A description for search engines'
     );
   });
 
   it('extracts excerpt', () => {
-    const result = parseBlogMarkdown(validMarkdown);
-    expect(result.excerpt).toBe('A short excerpt for the post');
+    expect(parseBlogMarkdown(frontmatterMd).excerpt).toBe('A short excerpt');
   });
 
-  it('extracts source project', () => {
-    const result = parseBlogMarkdown(validMarkdown);
-    expect(result.sourceProject).toBe('ghost-mcp');
+  it('extracts tags as array', () => {
+    expect(parseBlogMarkdown(frontmatterMd).tags).toEqual(['dev', 'ghost', 'mcp']);
   });
 
-  it('extracts tech stack as array', () => {
-    const result = parseBlogMarkdown(validMarkdown);
-    expect(result.techStack).toEqual(['TypeScript', 'Node.js']);
-  });
+  it('supports title in frontmatter instead of heading', () => {
+    const md = `---
+title: From Frontmatter
+---
 
-  it('extracts keywords as array', () => {
-    const result = parseBlogMarkdown(validMarkdown);
-    expect(result.keywords).toEqual(['MCP', 'Ghost', '블로그']);
-  });
-
-  // ── Edge cases ──
-
-  it('returns empty strings when markers are missing', () => {
-    const result = parseBlogMarkdown('Just some text');
-    expect(result.title).toBe('');
-    expect(result.body).toBe('');
-    expect(result.slug).toBe('');
-  });
-
-  it('handles missing SEO section gracefully', () => {
-    const md = `# Title
-
-<!-- 본문 시작 -->
-Body here
-<!-- MCP 파싱 마커: end -->
+Body without heading.
 `;
     const result = parseBlogMarkdown(md);
-    expect(result.title).toBe('Title');
-    expect(result.body).toBe('Body here');
+    expect(result.title).toBe('From Frontmatter');
+    expect(result.body).toBe('Body without heading.');
+  });
+
+  it('heading title overrides frontmatter title', () => {
+    const md = `---
+title: Frontmatter Title
+---
+
+# Heading Title
+
+Body here.
+`;
+    // First # heading found in body, so frontmatter title is fallback
+    // Actually the code checks meta.title || heading, but heading is found
+    // Let's verify the behavior
+    const result = parseBlogMarkdown(md);
+    // Title from frontmatter is used only when no heading exists
+    expect(result.title).toBeTruthy();
+  });
+
+  it('handles empty frontmatter values', () => {
+    const md = `---
+slug:
+meta_title: ~
+---
+
+# Title
+
+Body.
+`;
+    const result = parseBlogMarkdown(md);
     expect(result.slug).toBe('');
     expect(result.metaTitle).toBe('');
+  });
+
+  it('handles quoted values', () => {
+    const md = `---
+slug: "my-slug"
+meta_title: 'Single Quoted'
+---
+
+# Title
+
+Body.
+`;
+    const result = parseBlogMarkdown(md);
+    expect(result.slug).toBe('my-slug');
+    expect(result.metaTitle).toBe('Single Quoted');
+  });
+
+  it('handles tags as comma-separated string', () => {
+    const md = `---
+tags: dev, ghost, mcp
+---
+
+# Title
+
+Body.
+`;
+    expect(parseBlogMarkdown(md).tags).toEqual(['dev', 'ghost', 'mcp']);
+  });
+});
+
+// ── Plain markdown format ────────────────────────
+
+describe('parseBlogMarkdown — plain markdown', () => {
+  it('extracts title and body from plain markdown', () => {
+    const md = `# My Post
+
+This is the content.
+
+Second paragraph.
+`;
+    const result = parseBlogMarkdown(md);
+    expect(result.title).toBe('My Post');
+    expect(result.body).toContain('This is the content.');
+    expect(result.body).toContain('Second paragraph.');
+  });
+
+  it('returns empty title when no heading', () => {
+    const result = parseBlogMarkdown('Just some text without heading.');
+    expect(result.title).toBe('');
+    expect(result.body).toBe('Just some text without heading.');
+  });
+
+  it('returns empty metadata', () => {
+    const result = parseBlogMarkdown('# Title\n\nBody');
+    expect(result.slug).toBe('');
+    expect(result.metaTitle).toBe('');
+    expect(result.tags).toEqual([]);
   });
 
   it('handles title with special characters', () => {
     const md = `# React에서 "useState" vs useReducer — 비교 & 분석
 
-<!-- 본문 시작 -->
-content
-<!-- MCP 파싱 마커 -->
+content here
 `;
-    const result = parseBlogMarkdown(md);
-    expect(result.title).toBe(
+    expect(parseBlogMarkdown(md).title).toBe(
       'React에서 "useState" vs useReducer — 비교 & 분석'
     );
+  });
+});
+
+// ── Legacy marker format ─────────────────────────
+
+describe('parseBlogMarkdown — legacy marker format', () => {
+  const legacyMd = `# Legacy Post
+
+**소스 프로젝트:** \`ghost-mcp\`
+
+---
+
+<!-- 본문 시작 -->
+
+This is the **body**.
+
+<!-- MCP 파싱 마커: 본문은 여기까지 -->
+
+## Ghost SEO 설정
+
+| Field | Value |
+|-------|-------|
+| Post URL | \`legacy-slug\` |
+| Meta title | Legacy SEO Title |
+| Meta description | Legacy description |
+| Excerpt | Legacy excerpt |
+`;
+
+  it('detects legacy format by markers', () => {
+    const result = parseBlogMarkdown(legacyMd);
+    expect(result.title).toBe('Legacy Post');
+    expect(result.body).toBe('This is the **body**.');
+  });
+
+  it('extracts SEO fields from table', () => {
+    const result = parseBlogMarkdown(legacyMd);
+    expect(result.slug).toBe('legacy-slug');
+    expect(result.metaTitle).toBe('Legacy SEO Title');
+    expect(result.metaDescription).toBe('Legacy description');
+    expect(result.excerpt).toBe('Legacy excerpt');
+  });
+
+  it('returns empty tags for legacy format', () => {
+    expect(parseBlogMarkdown(legacyMd).tags).toEqual([]);
   });
 });
 
@@ -139,8 +230,7 @@ describe('toMobiledoc', () => {
   });
 
   it('returns valid JSON string', () => {
-    const result = toMobiledoc('test');
-    expect(() => JSON.parse(result)).not.toThrow();
+    expect(() => JSON.parse(toMobiledoc('test'))).not.toThrow();
   });
 });
 
@@ -163,7 +253,6 @@ describe('toLexical', () => {
   });
 
   it('returns valid JSON string', () => {
-    const result = toLexical('test');
-    expect(() => JSON.parse(result)).not.toThrow();
+    expect(() => JSON.parse(toLexical('test'))).not.toThrow();
   });
 });

--- a/src/parsers/markdown-parser.ts
+++ b/src/parsers/markdown-parser.ts
@@ -6,85 +6,160 @@ export interface ParsedBlogPost {
   metaTitle: string;
   metaDescription: string;
   excerpt: string;
-  sourceProject: string;
-  techStack: string[];
-  keywords: string[];
+  tags: string[];
 }
 
-const END_MARKER = /<!--\s*MCP 파싱 마커/;
+const LEGACY_BODY_START = /<!--\s*본문 시작\s*-->/;
+const LEGACY_END_MARKER = /<!--\s*MCP 파싱 마커/;
+const FRONTMATTER_FENCE = /^---\s*$/m;
 
 /**
- * Parse blog markdown written by /blog command.
+ * Auto-detect format and parse markdown into a Ghost-ready structure.
  *
- * Structure:
- *   # Title
- *   ... metadata block ...
- *   ---
- *   <!-- 본문 시작 -->
- *   ... body ...
- *   <!-- MCP 파싱 마커: 본문은 여기까지, ... -->
- *   ... Ghost SEO 설정 table ...
+ * Supported formats:
+ *
+ * 1. **Standard frontmatter** (recommended for public use):
+ *    ---
+ *    slug: my-post
+ *    meta_title: SEO Title
+ *    meta_description: Description
+ *    excerpt: Short excerpt
+ *    tags: [dev, ghost]
+ *    ---
+ *    # Title
+ *    Body content...
+ *
+ * 2. **Plain markdown** (no frontmatter, no markers):
+ *    # Title
+ *    Body content...
+ *
+ * 3. **Legacy marker format** (internal /blog command):
+ *    <!-- 본문 시작 --> ... <!-- MCP 파싱 마커 -->
  */
 export function parseBlogMarkdown(content: string): ParsedBlogPost {
-  // 1. Title: first # heading
+  // Auto-detect: legacy markers take priority if present
+  if (LEGACY_BODY_START.test(content) && LEGACY_END_MARKER.test(content)) {
+    return parseLegacyFormat(content);
+  }
+
+  // Check for YAML frontmatter (starts with ---)
+  if (content.trimStart().startsWith('---')) {
+    return parseFrontmatterFormat(content);
+  }
+
+  // Plain markdown: title from first # heading, rest is body
+  return parsePlainMarkdown(content);
+}
+
+/** Standard YAML frontmatter format */
+function parseFrontmatterFormat(content: string): ParsedBlogPost {
+  const trimmed = content.trimStart();
+  // Split on the second --- fence
+  const afterFirst = trimmed.slice(3); // skip opening ---
+  const closingIdx = afterFirst.search(FRONTMATTER_FENCE);
+
+  if (closingIdx === -1) {
+    return parsePlainMarkdown(content);
+  }
+
+  const yamlBlock = afterFirst.slice(0, closingIdx).trim();
+  const bodyContent = afterFirst.slice(closingIdx).replace(FRONTMATTER_FENCE, '').trim();
+
+  // Simple YAML key-value parser (no dependency needed)
+  const meta = parseSimpleYaml(yamlBlock);
+
+  // Title: from frontmatter or first # heading in body
+  const titleMatch = bodyContent.match(/^# (.+)$/m);
+  const title = (meta.title as string) || (titleMatch ? titleMatch[1].trim() : '');
+
+  // Body: everything after title heading, or full body if no heading
+  let body = bodyContent;
+  if (titleMatch) {
+    body = bodyContent.slice(bodyContent.indexOf(titleMatch[0]) + titleMatch[0].length).trim();
+  }
+
+  // Tags: array or comma-separated string
+  let tags: string[] = [];
+  if (meta.tags) {
+    if (Array.isArray(meta.tags)) {
+      tags = meta.tags.map(String);
+    } else {
+      tags = String(meta.tags).split(/[,，]/).map(s => s.trim()).filter(Boolean);
+    }
+  }
+
+  return {
+    title,
+    body,
+    slug: String(meta.slug || meta.post_url || ''),
+    metaTitle: String(meta.meta_title || ''),
+    metaDescription: String(meta.meta_description || ''),
+    excerpt: String(meta.excerpt || meta.custom_excerpt || ''),
+    tags,
+  };
+}
+
+/** Plain markdown: # Title + body, no metadata */
+function parsePlainMarkdown(content: string): ParsedBlogPost {
   const titleMatch = content.match(/^# (.+)$/m);
   const title = titleMatch ? titleMatch[1].trim() : '';
 
-  // 2. Body: between markers
+  let body = content;
+  if (titleMatch) {
+    body = content.slice(content.indexOf(titleMatch[0]) + titleMatch[0].length).trim();
+  }
+
+  return { title, body, slug: '', metaTitle: '', metaDescription: '', excerpt: '', tags: [] };
+}
+
+/** Legacy format with Korean markers (internal /blog command) */
+function parseLegacyFormat(content: string): ParsedBlogPost {
+  const titleMatch = content.match(/^# (.+)$/m);
+  const title = titleMatch ? titleMatch[1].trim() : '';
+
   const bodyMatch = content.match(
     /<!--\s*본문 시작\s*-->([\s\S]*?)(?=<!--\s*MCP 파싱 마커)/
   );
   const body = bodyMatch ? bodyMatch[1].trim() : '';
 
-  // 3. SEO section: after the end marker
-  const seoSection = content.split(END_MARKER)[1] || '';
+  const seoSection = content.split(LEGACY_END_MARKER)[1] || '';
 
-  // Ghost SEO 설정 table parsing
   const postUrlMatch = seoSection.match(/\| Post URL \| `([^`]+)` \|/);
   const metaTitleMatch = seoSection.match(/\| Meta title \| (.+?) \|/);
   const metaDescMatch = seoSection.match(/\| Meta description \| (.+?) \|/);
   const excerptMatch = seoSection.match(/\| Excerpt \| (.+?) \|/);
 
-  const slug = postUrlMatch ? postUrlMatch[1].trim() : '';
-  const metaTitle = metaTitleMatch ? metaTitleMatch[1].trim() : '';
-  const metaDescription = metaDescMatch ? metaDescMatch[1].trim() : '';
-  const excerpt = excerptMatch ? excerptMatch[1].trim() : '';
-
-  // 4. Metadata block
-  const sourceProjectMatch = content.match(
-    /\*\*소스 프로젝트:\*\*\s*`([^`]+)`/
-  );
-  const sourceProject = sourceProjectMatch
-    ? sourceProjectMatch[1].trim()
-    : '';
-
-  const techStackMatch = content.match(/\*\*기술 스택:\*\*\s*(.+)/);
-  const techStack = techStackMatch
-    ? techStackMatch[1]
-        .split(/[,，]/)
-        .map((s) => s.trim())
-        .filter(Boolean)
-    : [];
-
-  const keywordsMatch = content.match(/\*\*키워드:\*\*\s*(.+)/);
-  const keywords = keywordsMatch
-    ? keywordsMatch[1]
-        .split(/[,，]/)
-        .map((s) => s.trim())
-        .filter(Boolean)
-    : [];
-
   return {
     title,
     body,
-    slug,
-    metaTitle,
-    metaDescription,
-    excerpt,
-    sourceProject,
-    techStack,
-    keywords,
+    slug: postUrlMatch ? postUrlMatch[1].trim() : '',
+    metaTitle: metaTitleMatch ? metaTitleMatch[1].trim() : '',
+    metaDescription: metaDescMatch ? metaDescMatch[1].trim() : '',
+    excerpt: excerptMatch ? excerptMatch[1].trim() : '',
+    tags: [],
   };
+}
+
+/** Minimal YAML parser for frontmatter (key: value, arrays) */
+function parseSimpleYaml(yaml: string): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  for (const line of yaml.split('\n')) {
+    const match = line.match(/^(\w[\w_]*):\s*(.*)$/);
+    if (!match) continue;
+    const [, key, rawValue] = match;
+    const value = rawValue.trim();
+
+    // Array: [a, b, c]
+    if (value.startsWith('[') && value.endsWith(']')) {
+      result[key] = value.slice(1, -1).split(',').map(s => s.trim().replace(/^["']|["']$/g, '')).filter(Boolean);
+    } else if (value === '' || value === '~' || value === 'null') {
+      result[key] = '';
+    } else {
+      // Strip surrounding quotes
+      result[key] = value.replace(/^["']|["']$/g, '');
+    }
+  }
+  return result;
 }
 
 /** Convert markdown body to Ghost mobiledoc JSON string */

--- a/src/parsers/markdown-parser.ts
+++ b/src/parsers/markdown-parser.ts
@@ -66,7 +66,12 @@ function parseFrontmatterFormat(content: string): ParsedBlogPost {
   const bodyContent = afterFirst.slice(closingIdx).replace(FRONTMATTER_FENCE, '').trim();
 
   // Simple YAML key-value parser (no dependency needed)
-  const meta = parseSimpleYaml(yamlBlock);
+  // Normalize hyphenated keys (meta-title → meta_title)
+  const rawMeta = parseSimpleYaml(yamlBlock);
+  const meta: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(rawMeta)) {
+    meta[k.replace(/-/g, '_')] = v;
+  }
 
   // Title: from frontmatter or first # heading in body
   const titleMatch = bodyContent.match(/^# (.+)$/m);
@@ -140,25 +145,48 @@ function parseLegacyFormat(content: string): ParsedBlogPost {
   };
 }
 
-/** Minimal YAML parser for frontmatter (key: value, arrays) */
+/** Minimal YAML parser for frontmatter (key: value, inline/block arrays) */
 function parseSimpleYaml(yaml: string): Record<string, unknown> {
   const result: Record<string, unknown> = {};
-  for (const line of yaml.split('\n')) {
-    const match = line.match(/^(\w[\w_]*):\s*(.*)$/);
+  const lines = yaml.split('\n');
+  let currentKey = '';
+
+  for (let i = 0; i < lines.length; i++) {
+    // Block sequence item: "  - value"
+    const seqMatch = lines[i].match(/^\s+-\s+(.+)$/);
+    if (seqMatch && currentKey) {
+      const arr = result[currentKey];
+      if (Array.isArray(arr)) {
+        arr.push(seqMatch[1].trim().replace(/^["']|["']$/g, ''));
+      }
+      continue;
+    }
+
+    // Key-value pair (supports hyphens in keys: meta-title, og-image)
+    const match = lines[i].match(/^([\w][\w_-]*):\s*(.*)$/);
     if (!match) continue;
     const [, key, rawValue] = match;
     const value = rawValue.trim();
+    currentKey = key;
 
-    // Array: [a, b, c]
+    // Inline array: [a, b, c]
     if (value.startsWith('[') && value.endsWith(']')) {
       result[key] = value.slice(1, -1).split(',').map(s => s.trim().replace(/^["']|["']$/g, '')).filter(Boolean);
     } else if (value === '' || value === '~' || value === 'null') {
-      result[key] = '';
+      // Empty value — could be start of a block sequence
+      result[key] = [];
     } else {
-      // Strip surrounding quotes
       result[key] = value.replace(/^["']|["']$/g, '');
     }
   }
+
+  // Convert empty arrays back to empty string if no items were added
+  for (const [key, val] of Object.entries(result)) {
+    if (Array.isArray(val) && val.length === 0) {
+      result[key] = '';
+    }
+  }
+
   return result;
 }
 

--- a/src/tools/sync-tools.ts
+++ b/src/tools/sync-tools.ts
@@ -57,7 +57,7 @@ export function registerSyncTools(
           content: [
             {
               type: 'text' as const,
-              text: 'Error: Could not extract body. Make sure <!-- 본문 시작 --> and <!-- MCP 파싱 마커 --> markers exist.',
+              text: 'Error: Could not extract body. Use one of these formats:\n1. Standard: YAML frontmatter (---) + # Title + body\n2. Plain: # Title + body\n3. Legacy: <!-- 본문 시작 --> ... <!-- MCP 파싱 마커 --> markers',
             },
           ],
           isError: true,
@@ -89,6 +89,7 @@ export function registerSyncTools(
           meta_title: parsed.metaTitle || undefined,
           meta_description: parsed.metaDescription || undefined,
           custom_excerpt: parsed.excerpt || undefined,
+          ...(parsed.tags.length > 0 && { tags: parsed.tags.map(name => ({ name })) }),
         });
         action = 'updated';
       } else {
@@ -100,6 +101,7 @@ export function registerSyncTools(
           meta_title: parsed.metaTitle || undefined,
           meta_description: parsed.metaDescription || undefined,
           custom_excerpt: parsed.excerpt || undefined,
+          ...(parsed.tags.length > 0 && { tags: parsed.tags.map(name => ({ name })) }),
           status: 'draft',
         });
         action = 'created';
@@ -138,17 +140,17 @@ export function registerSyncTools(
               `| Meta title | ${parsed.metaTitle || 'N/A'} |`,
               `| Meta desc | ${parsed.metaDescription || 'N/A'} |`,
               `| Excerpt | ${parsed.excerpt || 'N/A'} |`,
-              `| Source project | ${parsed.sourceProject || 'N/A'} |`,
               '',
-              `**Tags are not yet assigned.** Review the content and pick appropriate tags from the list below, then use \`ghost_update_post\` to apply them.`,
+              parsed.tags.length > 0
+                ? `**Tags applied:** ${parsed.tags.join(', ')}`
+                : `**Tags are not yet assigned.** Review the content and pick appropriate tags from the list below, then use \`ghost_update_post\` to apply them.`,
               '',
               `## Existing tags`,
               tagList,
               '',
-              `## Content keywords for reference`,
-              `Source project: ${parsed.sourceProject || 'N/A'}`,
-              `Tech stack: ${parsed.techStack.join(', ') || 'N/A'}`,
-              `Keywords: ${parsed.keywords.join(', ') || 'N/A'}`,
+              parsed.tags.length > 0
+                ? `## Tags from frontmatter\n${parsed.tags.join(', ')}`
+                : '',
             ].join('\n'),
           },
         ],

--- a/src/tools/sync-tools.ts
+++ b/src/tools/sync-tools.ts
@@ -89,7 +89,7 @@ export function registerSyncTools(
           meta_title: parsed.metaTitle || undefined,
           meta_description: parsed.metaDescription || undefined,
           custom_excerpt: parsed.excerpt || undefined,
-          ...(parsed.tags.length > 0 && { tags: parsed.tags.map(name => ({ name })) }),
+          tags: parsed.tags.map(name => ({ name })),
         });
         action = 'updated';
       } else {
@@ -143,14 +143,10 @@ export function registerSyncTools(
               '',
               parsed.tags.length > 0
                 ? `**Tags applied:** ${parsed.tags.join(', ')}`
-                : `**Tags are not yet assigned.** Review the content and pick appropriate tags from the list below, then use \`ghost_update_post\` to apply them.`,
+                : `**Tags are not yet assigned.** Pick from the list below, then use \`ghost_update_post\` to apply.`,
               '',
               `## Existing tags`,
               tagList,
-              '',
-              parsed.tags.length > 0
-                ? `## Tags from frontmatter\n${parsed.tags.join(', ')}`
-                : '',
             ].join('\n'),
           },
         ],

--- a/src/tools/tools.test.ts
+++ b/src/tools/tools.test.ts
@@ -342,3 +342,50 @@ describe('Sync Tools (MCP integration)', () => {
     expect(text).toContain('Sync Status');
   });
 });
+
+// ── Sync Tools — tag clearing regression ─────────
+
+describe('Sync Tools — tag clearing on update (regression #1)', () => {
+  let client: Client;
+  let ghost: GhostAdminApi;
+  let indexManager: IndexManager;
+  let syncDir: string;
+
+  beforeAll(async () => {
+    ghost = createMockGhost();
+    indexManager = new IndexManager();
+    syncDir = path.resolve(process.env.HOME || '~', 'blog-drafts');
+    await fs.mkdir(syncDir, { recursive: true });
+    ({ client } = await setupMcpClient(ghost, indexManager));
+  });
+
+  afterAll(async () => {
+    await client.close();
+    // Clean up test file
+    await fs.unlink(path.join(syncDir, 'tag-test.md')).catch(() => {});
+  });
+
+  it('sends empty tags array on update when markdown has no tags', async () => {
+    const testFile = path.join(syncDir, 'tag-test.md');
+    await fs.writeFile(testFile, '# No Tags Post\n\nBody without frontmatter tags.');
+
+    // Pre-seed index so push triggers update path
+    await indexManager.setEntry('tag-test.md', {
+      ghostId: '507f1f77bcf86cd799439011',
+      ghostSlug: 'tag-test',
+      ghostStatus: 'draft',
+      ghostUpdatedAt: '2026-01-01T00:00:00.000Z',
+      localHash: 'old-hash',
+      lastPushed: '2026-01-01T00:00:00.000Z',
+    });
+
+    await client.callTool({
+      name: 'ghost_push_local',
+      arguments: { file_path: testFile },
+    });
+
+    expect(ghost.updatePost).toHaveBeenCalledWith(
+      expect.objectContaining({ tags: [] })
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- YAML frontmatter, 일반 마크다운, 레거시 마커 3가지 형식 자동 감지
- frontmatter에서 tags 지정 시 Ghost에 자동 태그 할당
- `ParsedBlogPost` 인터페이스 범용화 (sourceProject/techStack/keywords → tags)

## Changes
### Parser (`src/parsers/markdown-parser.ts`)
- `parseFrontmatterFormat()`: YAML frontmatter 파싱 (slug, meta_title, tags 등)
- `parsePlainMarkdown()`: 일반 마크다운 (# Title + body)
- `parseLegacyFormat()`: 기존 한글 마커 형식 (하위 호환)
- `parseSimpleYaml()`: 경량 YAML 파서 (외부 의존성 없음)

### Sync tools (`src/tools/sync-tools.ts`)
- frontmatter tags → Ghost 태그 자동 할당
- 에러 메시지에 3가지 형식 안내 추가

### Tests
- frontmatter/plain/legacy 형식별 테스트 (94 tests total)

## Test plan
- [x] `npm test` — 94 tests passed
- [x] `npm run build` — clean
- [x] Legacy marker format backward compatible

Closes #N/A