### PR TITLE
feat: add McpServer instructions and sync version from package.json

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -1,3 +1,6 @@
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, resolve } from 'path';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { GhostAdminApi } from './ghost/client.js';
 import { IndexManager } from './sync/index-manager.js';
@@ -7,11 +10,30 @@ import { registerPageTools } from './tools/page-tools.js';
 import { registerSyncTools } from './tools/sync-tools.js';
 import type { Config } from './config.js';
 
+const pkgPath = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  '..',
+  'package.json'
+);
+const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8')) as { version: string };
+
+const SERVER_INSTRUCTIONS = `Ghost blog management server.
+
+Tool-selection guidance:
+- For posts authored locally in ~/blog-drafts/, prefer \`ghost_push_local\` — it parses frontmatter, hashes for sync tracking, and returns existing tags for reuse.
+- For ad-hoc in-chat drafts, use \`ghost_create_post\` with markdown.
+- Before \`ghost_update_post\` changes tags, call \`ghost_list_tags\` to avoid duplicates — Ghost auto-creates unknown tag names.
+- \`ghost_update_post\` handles optimistic locking internally. Do NOT fetch updated_at first.
+- To publish-and-email, call \`ghost_list_newsletters\` for the slug, then pass \`newsletter\` + \`status: published\` to \`ghost_update_post\`.
+- \`ghost_delete_post\` / \`ghost_delete_tag\` require \`confirm: true\` as a safety flag.
+- Start with \`ghost_analyze_tags\` for SEO tag cleanup work.
+- Use \`ghost_sync_status\` to detect drift between ~/blog-drafts/ and Ghost.`;
+
 export function createServer(config: Config): McpServer {
-  const server = new McpServer({
-    name: 'ghost-blog',
-    version: '1.0.0',
-  });
+  const server = new McpServer(
+    { name: 'ghost-blog', version: pkg.version },
+    { instructions: SERVER_INSTRUCTIONS }
+  );
 
   const ghost = new GhostAdminApi(config.ghostUrl, config.ghostAdminApiKey);
   const indexManager = new IndexManager();

--- a/src/server.ts
+++ b/src/server.ts
@@ -10,12 +10,23 @@ import { registerPageTools } from './tools/page-tools.js';
 import { registerSyncTools } from './tools/sync-tools.js';
 import type { Config } from './config.js';
 
-const pkgPath = resolve(
-  dirname(fileURLToPath(import.meta.url)),
-  '..',
-  'package.json'
-);
-const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8')) as { version: string };
+function loadPackageVersion(): string {
+  try {
+    const pkgPath = resolve(
+      dirname(fileURLToPath(import.meta.url)),
+      '..',
+      'package.json'
+    );
+    const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8')) as {
+      version?: string;
+    };
+    return pkg.version ?? '0.0.0';
+  } catch {
+    return '0.0.0';
+  }
+}
+
+const PKG_VERSION = loadPackageVersion();
 
 const SERVER_INSTRUCTIONS = `Ghost blog management server.
 
@@ -31,7 +42,7 @@ Tool-selection guidance:
 
 export function createServer(config: Config): McpServer {
   const server = new McpServer(
-    { name: 'ghost-blog', version: pkg.version },
+    { name: 'ghost-blog', version: PKG_VERSION },
     { instructions: SERVER_INSTRUCTIONS }
   );
 


### PR DESCRIPTION
## Summary
- Add \`SERVER_INSTRUCTIONS\` with tool-selection guidance (when to prefer \`ghost_push_local\` over \`ghost_create_post\`, call-order for tag updates, optimistic-locking note, publish-and-email workflow)
- Load version dynamically from \`package.json\` at runtime via \`readFileSync\` — eliminates the drift between hardcoded \`1.0.0\` and \`package.json\` \`1.0.1\`

## Why
Server-level instructions ship once on init and orient Claude's tool choice across the whole session — more effective per-token than repeating guidance in individual tool descriptions. The version drift is a small bug but will grow on every release.

## Implementation notes
- \`McpServer\` accepts \`instructions\` via its second arg (\`ServerOptions\`), not the first \`Implementation\` object
- \`rootDir: "src"\` in tsconfig prevents importing \`../package.json\` via \`with { type: 'json' }\`, so runtime \`readFileSync\` is used instead. The path is resolved from \`import.meta.url\` so it works from both \`src/\` (vitest) and \`dist/\` (production)

## Test plan
- [x] \`npm run build\` passes
- [x] \`npm test\` — 97/97 tests still pass
- [x] Smoke test: \`node -e "import('./dist/server.js').then(m => m.createServer(...))"\` succeeds

Closes #3