### PR TITLE
feat: support 'sent' post status in list filter

### DIFF
--- a/src/ghost/types.ts
+++ b/src/ghost/types.ts
@@ -3,7 +3,7 @@ export interface GhostPost {
   uuid: string;
   title: string;
   slug: string;
-  status: 'draft' | 'published' | 'scheduled';
+  status: 'draft' | 'published' | 'scheduled' | 'sent';
   published_at: string | null;
   updated_at: string;
   created_at: string;

--- a/src/tools/post-tools.ts
+++ b/src/tools/post-tools.ts
@@ -14,9 +14,11 @@ export function registerPostTools(server: McpServer, ghost: GhostAdminApi) {
     'List Ghost blog posts with optional filters',
     {
       status: z
-        .enum(['draft', 'published', 'scheduled'])
+        .enum(['draft', 'published', 'scheduled', 'sent'])
         .optional()
-        .describe('Filter by post status'),
+        .describe(
+          'Filter by post status. "sent" returns posts that were emailed as a newsletter (system-set, read-only — cannot be set via ghost_update_post).'
+        ),
       tag: z.string().optional().describe('Filter by tag slug'),
       search: z.string().optional().describe('Search in title and content'),
       limit: z.number().optional().describe('Max posts to return (default 50)'),

--- a/src/tools/tools.test.ts
+++ b/src/tools/tools.test.ts
@@ -118,6 +118,17 @@ describe('Post Tools (MCP integration)', () => {
     expect(text).toContain('Test Post');
   });
 
+  it('ghost_list_posts accepts status: sent and forwards it to getPosts', async () => {
+    const result = await client.callTool({
+      name: 'ghost_list_posts',
+      arguments: { status: 'sent' },
+    });
+    expect(result.isError).toBeFalsy();
+    expect(ghost.getPosts).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'sent' })
+    );
+  });
+
   it('ghost_get_post accepts valid ID', async () => {
     const result = await client.callTool({
       name: 'ghost_get_post',


### PR DESCRIPTION
## Summary
- Add \`'sent'\` to the status enum of \`ghost_list_posts\` so users can filter newsletter-emailed posts
- Intentionally **not** added to \`ghost_update_post\` — \`sent\` is a system-set read-only transition

## Why
After \`ghost_update_post\` with \`newsletter: '<slug>'\` and \`status: published\`, Ghost automatically transitions the post to \`sent\` state. Previously, \`ghost_list_posts\` rejected \`status: sent\` at the zod validation layer, making it impossible to query those posts.

## Decision: list-only, not update
Ghost's status lifecycle treats \`sent\` as read-only — users should not be able to manually set a post to \`sent\` outside of a real newsletter send. Keeping it out of \`ghost_update_post.status\` preserves that invariant at the tool layer instead of relying on the API to reject invalid writes.

## Test plan
- [x] \`npm run build\` passes
- [x] \`npm test\` — 97/97 tests still pass
- [ ] Manual verification against a live Ghost instance that supports \`filter=status:sent\` (not gating — Ghost docs confirm this is a legal filter value)

Closes #10