### PR TITLE
feat: surface email engagement metrics in post read paths

### DIFF
--- a/scripts/verify-email-metrics.mjs
+++ b/scripts/verify-email-metrics.mjs
@@ -76,17 +76,18 @@ async function main() {
   console.log('\nNewsletter object:');
   console.log(JSON.stringify(post.newsletter, null, 2));
 
-  // 2. Full email object via separate endpoint.
+  // 2. Full email object via separate endpoint. Cache for section 3 reuse.
+  let fullEmail = null;
   if (post.email?.id) {
     console.log('\n## 2. Full email object (via GET /emails/:email_id/)\n');
     try {
       const emailRes = await get(`emails/${post.email.id}/`);
-      const email = emailRes.emails?.[0];
-      console.log('Full email keys:', Object.keys(email || {}).sort());
+      fullEmail = emailRes.emails?.[0] ?? null;
+      console.log('Full email keys:', Object.keys(fullEmail || {}).sort());
       console.log('Full email sample:');
       console.log(
         JSON.stringify(
-          email,
+          fullEmail,
           (k, v) =>
             // hide bulky html/plaintext to keep output readable
             k === 'html' || k === 'plaintext'
@@ -100,18 +101,10 @@ async function main() {
     }
   }
 
-  // 3. Diff of keys between embedded and full
+  // 3. Diff of keys between embedded and full (reuse fullEmail from section 2)
   console.log('\n## 3. Field availability summary\n');
   const embeddedKeys = new Set(Object.keys(post.email || {}));
-  let fullKeys = new Set();
-  if (post.email?.id) {
-    try {
-      const emailRes = await get(`emails/${post.email.id}/`);
-      fullKeys = new Set(Object.keys(emailRes.emails?.[0] || {}));
-    } catch {
-      /* already logged */
-    }
-  }
+  const fullKeys = new Set(Object.keys(fullEmail || {}));
   const onlyEmbedded = [...embeddedKeys].filter((k) => !fullKeys.has(k));
   const onlyFull = [...fullKeys].filter((k) => !embeddedKeys.has(k));
   const common = [...embeddedKeys].filter((k) => fullKeys.has(k));

--- a/scripts/verify-email-metrics.mjs
+++ b/scripts/verify-email-metrics.mjs
@@ -1,0 +1,135 @@
+#!/usr/bin/env node
+/**
+ * Dev-only verifier for Ghost Admin API email engagement payload shape.
+ * Probes a sent post via two paths:
+ *   1. GET /admin/posts/:id/?include=email — embedded email object
+ *   2. GET /admin/emails/:email_id/        — full email object via separate endpoint
+ * and prints the union of all field names + sample values so we can decide
+ * what's safe to surface in MCP read paths.
+ *
+ * Self-contained (no project deps).
+ *
+ * Usage:
+ *   GHOST_URL=https://blog.example.com \
+ *   GHOST_ADMIN_API_KEY=id:secret \
+ *   node scripts/verify-email-metrics.mjs
+ */
+import crypto from 'crypto';
+
+const url = process.env.GHOST_URL;
+const key = process.env.GHOST_ADMIN_API_KEY;
+if (!url || !key) {
+  console.error('Missing GHOST_URL or GHOST_ADMIN_API_KEY');
+  process.exit(1);
+}
+
+function jwt() {
+  const [id, secret] = key.split(':');
+  const iat = Math.floor(Date.now() / 1000);
+  const enc = (o) => Buffer.from(JSON.stringify(o)).toString('base64url');
+  const h = enc({ alg: 'HS256', typ: 'JWT', kid: id });
+  const p = enc({ iat, exp: iat + 300, aud: '/admin/' });
+  const sig = crypto
+    .createHmac('sha256', Buffer.from(secret, 'hex'))
+    .update(`${h}.${p}`)
+    .digest('base64url');
+  return `${h}.${p}.${sig}`;
+}
+
+async function get(path) {
+  const res = await fetch(`${url.replace(/\/$/, '')}/ghost/api/admin/${path}`, {
+    headers: { Authorization: `Ghost ${jwt()}` },
+  });
+  if (!res.ok) {
+    const txt = await res.text();
+    throw new Error(`HTTP ${res.status}: ${txt.slice(0, 300)}`);
+  }
+  return res.json();
+}
+
+async function main() {
+  console.log(`URL: ${url}\n`);
+
+  // Find a post that has been sent or has email object populated.
+  console.log('## Searching for a sent/published post with email payload...\n');
+  const filter = encodeURIComponent('status:[published,sent]');
+  const list = await get(
+    `posts/?filter=${filter}&limit=20&include=email,newsletter&order=published_at%20desc`
+  );
+  const candidate = list.posts?.find((p) => p.email && p.email.id);
+  if (!candidate) {
+    console.log('No post with embedded email object found. Aborting.');
+    return;
+  }
+
+  console.log(`Found: ${candidate.slug} (status=${candidate.status})\n`);
+
+  // 1. Embedded email object via post endpoint.
+  console.log('## 1. Embedded email object (via GET /posts/:id/?include=email,newsletter)\n');
+  const detail = await get(
+    `posts/${candidate.id}/?include=email,newsletter`
+  );
+  const post = detail.posts?.[0];
+  console.log('Embedded email keys:', Object.keys(post.email || {}).sort());
+  console.log('Embedded email sample:');
+  console.log(JSON.stringify(post.email, null, 2));
+  console.log('\nNewsletter object:');
+  console.log(JSON.stringify(post.newsletter, null, 2));
+
+  // 2. Full email object via separate endpoint.
+  if (post.email?.id) {
+    console.log('\n## 2. Full email object (via GET /emails/:email_id/)\n');
+    try {
+      const emailRes = await get(`emails/${post.email.id}/`);
+      const email = emailRes.emails?.[0];
+      console.log('Full email keys:', Object.keys(email || {}).sort());
+      console.log('Full email sample:');
+      console.log(
+        JSON.stringify(
+          email,
+          (k, v) =>
+            // hide bulky html/plaintext to keep output readable
+            k === 'html' || k === 'plaintext'
+              ? `[${typeof v === 'string' ? v.length : 0} chars]`
+              : v,
+          2
+        )
+      );
+    } catch (e) {
+      console.log(`Failed to fetch full email: ${e.message}`);
+    }
+  }
+
+  // 3. Diff of keys between embedded and full
+  console.log('\n## 3. Field availability summary\n');
+  const embeddedKeys = new Set(Object.keys(post.email || {}));
+  let fullKeys = new Set();
+  if (post.email?.id) {
+    try {
+      const emailRes = await get(`emails/${post.email.id}/`);
+      fullKeys = new Set(Object.keys(emailRes.emails?.[0] || {}));
+    } catch {
+      /* already logged */
+    }
+  }
+  const onlyEmbedded = [...embeddedKeys].filter((k) => !fullKeys.has(k));
+  const onlyFull = [...fullKeys].filter((k) => !embeddedKeys.has(k));
+  const common = [...embeddedKeys].filter((k) => fullKeys.has(k));
+  console.log(
+    `Common (${common.length}):`,
+    common.sort().join(', ') || '(none)'
+  );
+  console.log(
+    `Only in embedded (${onlyEmbedded.length}):`,
+    onlyEmbedded.sort().join(', ') || '(none)'
+  );
+  console.log(
+    `Only in full (${onlyFull.length}):`,
+    onlyFull.sort().join(', ') || '(none)'
+  );
+}
+
+main().catch((e) => {
+  console.error('Fatal:', e.message);
+  process.exit(2);
+});

--- a/scripts/verify-email-metrics.mjs
+++ b/scripts/verify-email-metrics.mjs
@@ -103,8 +103,12 @@ async function main() {
 
   // 3. Diff of keys between embedded and full (reuse fullEmail from section 2)
   console.log('\n## 3. Field availability summary\n');
+  if (!fullEmail) {
+    console.log('(skipped — full email payload unavailable, see section 2)');
+    return;
+  }
   const embeddedKeys = new Set(Object.keys(post.email || {}));
-  const fullKeys = new Set(Object.keys(fullEmail || {}));
+  const fullKeys = new Set(Object.keys(fullEmail));
   const onlyEmbedded = [...embeddedKeys].filter((k) => !fullKeys.has(k));
   const onlyFull = [...fullKeys].filter((k) => !embeddedKeys.has(k));
   const common = [...embeddedKeys].filter((k) => fullKeys.has(k));

--- a/src/ghost/types.ts
+++ b/src/ghost/types.ts
@@ -5,7 +5,6 @@
 
 export interface GhostEmail {
   id: string;
-  uuid?: string;
   status: string;
   recipient_filter: string | null;
   email_count?: number;
@@ -14,13 +13,6 @@ export interface GhostEmail {
   failed_count?: number;
   submitted_at?: string | null;
   error?: string | null;
-  error_data?: unknown;
-  subject?: string;
-  from?: string;
-  reply_to?: string | null;
-  track_opens?: boolean;
-  track_clicks?: boolean;
-  feedback_enabled?: boolean;
 }
 
 export interface GhostPost {

--- a/src/ghost/types.ts
+++ b/src/ghost/types.ts
@@ -5,13 +5,22 @@
 
 export interface GhostEmail {
   id: string;
+  uuid?: string;
   status: string;
   recipient_filter: string | null;
   email_count?: number;
   delivered_count?: number;
+  opened_count?: number;
   failed_count?: number;
   submitted_at?: string | null;
   error?: string | null;
+  error_data?: unknown;
+  subject?: string;
+  from?: string;
+  reply_to?: string | null;
+  track_opens?: boolean;
+  track_clicks?: boolean;
+  feedback_enabled?: boolean;
 }
 
 export interface GhostPost {

--- a/src/tools/post-tools.ts
+++ b/src/tools/post-tools.ts
@@ -56,14 +56,20 @@ export function registerPostTools(server: McpServer, ghost: GhostAdminApi) {
         const news = (p.newsletter?.slug || '-').slice(0, 18).padEnd(18);
         const segment = (p.email_segment ?? '-').slice(0, 14).padEnd(14);
         const emailStatus = (p.email?.status || '-').slice(0, 10).padEnd(10);
-        return `${base} ${news} | ${segment} | ${emailStatus} |`;
+        const recipients = (p.email?.email_count ?? '-').toString().slice(0, 5).padEnd(5);
+        const openRate =
+          p.email?.delivered_count && p.email.delivered_count > 0
+            ? `${(((p.email.opened_count ?? 0) / p.email.delivered_count) * 100).toFixed(0)}%`
+            : '-';
+        const open = openRate.slice(0, 5).padEnd(5);
+        return `${base} ${news} | ${segment} | ${emailStatus} | ${recipients} | ${open} |`;
       });
 
       const header = showEmail
-        ? '| Status    | Vis    | Date       | Title                                              | Tags                           | Slug | Newsletter         | Segment        | Email      |'
+        ? '| Status    | Vis    | Date       | Title                                              | Tags                           | Slug | Newsletter         | Segment        | Email      | Recip | Open% |'
         : '| Status    | Vis    | Date       | Title                                              | Tags                           | Slug |';
       const sep = showEmail
-        ? '|-----------|--------|------------|----------------------------------------------------|---------------------------------|------|--------------------|----------------|------------|'
+        ? '|-----------|--------|------------|----------------------------------------------------|---------------------------------|------|--------------------|----------------|------------|-------|-------|'
         : '|-----------|--------|------------|----------------------------------------------------|---------------------------------|------|';
 
       const total = pagination?.total ?? posts.length;
@@ -128,6 +134,22 @@ export function registerPostTools(server: McpServer, ghost: GhostAdminApi) {
         `| Email status | ${post.email?.status || 'not sent'} |`,
         `| Email recipient filter | ${post.email?.recipient_filter ?? 'N/A'} |`,
       ];
+
+      const e = post.email;
+      if (e && e.email_count !== undefined) {
+        const recipients = e.email_count;
+        const delivered = e.delivered_count ?? 0;
+        const opened = e.opened_count ?? 0;
+        const failed = e.failed_count ?? 0;
+        const pct = (n: number, d: number) =>
+          d > 0 ? `${((n / d) * 100).toFixed(1)}%` : '-';
+        lines.push(
+          `| Recipients | ${recipients} |`,
+          `| Delivered | ${delivered} / ${recipients} (${pct(delivered, recipients)}) |`,
+          `| Opened | ${opened} / ${delivered} (${pct(opened, delivered)}) |`,
+          `| Failed | ${failed} |`
+        );
+      }
 
       if (include_content) {
         if (post.lexical) {

--- a/src/tools/post-tools.ts
+++ b/src/tools/post-tools.ts
@@ -13,6 +13,10 @@ import type { GhostPost, GhostPostUpdate } from '../ghost/types.js';
 import { toMobiledoc, toLexical } from '../parsers/markdown-parser.js';
 import { ghostId, safeSlug, audit } from '../validation.js';
 
+function formatPct(n: number, d: number, digits = 1): string {
+  return d > 0 ? `${((n / d) * 100).toFixed(digits)}%` : '-';
+}
+
 export function registerPostTools(server: McpServer, ghost: GhostAdminApi) {
   server.tool(
     'ghost_list_posts',
@@ -57,10 +61,11 @@ export function registerPostTools(server: McpServer, ghost: GhostAdminApi) {
         const segment = (p.email_segment ?? '-').slice(0, 14).padEnd(14);
         const emailStatus = (p.email?.status || '-').slice(0, 10).padEnd(10);
         const recipients = (p.email?.email_count ?? '-').toString().slice(0, 5).padEnd(5);
-        const openRate =
-          p.email?.delivered_count && p.email.delivered_count > 0
-            ? `${(((p.email.opened_count ?? 0) / p.email.delivered_count) * 100).toFixed(0)}%`
-            : '-';
+        const openRate = formatPct(
+          p.email?.opened_count ?? 0,
+          p.email?.delivered_count ?? 0,
+          0
+        );
         const open = openRate.slice(0, 5).padEnd(5);
         return `${base} ${news} | ${segment} | ${emailStatus} | ${recipients} | ${open} |`;
       });
@@ -141,12 +146,10 @@ export function registerPostTools(server: McpServer, ghost: GhostAdminApi) {
         const delivered = e.delivered_count ?? 0;
         const opened = e.opened_count ?? 0;
         const failed = e.failed_count ?? 0;
-        const pct = (n: number, d: number) =>
-          d > 0 ? `${((n / d) * 100).toFixed(1)}%` : '-';
         lines.push(
           `| Recipients | ${recipients} |`,
-          `| Delivered | ${delivered} / ${recipients} (${pct(delivered, recipients)}) |`,
-          `| Opened | ${opened} / ${delivered} (${pct(opened, delivered)}) |`,
+          `| Delivered | ${delivered} / ${recipients} (${formatPct(delivered, recipients)}) |`,
+          `| Opened | ${opened} / ${delivered} (${formatPct(opened, delivered)}) |`,
           `| Failed | ${failed} |`
         );
       }

--- a/src/tools/tools.test.ts
+++ b/src/tools/tools.test.ts
@@ -21,7 +21,15 @@ import { registerSyncTools } from './sync-tools.js';
 // ── Mock Ghost API ──────────────────────────────
 
 function createMockGhost(overrides: Partial<{
-  email: { id: string; status: string; recipient_filter: string | null } | null;
+  email: {
+    id: string;
+    status: string;
+    recipient_filter: string | null;
+    email_count?: number;
+    delivered_count?: number;
+    opened_count?: number;
+    failed_count?: number;
+  } | null;
   newsletter: { id: string; name: string; slug: string } | null;
   email_segment: string;
   status: 'draft' | 'published' | 'scheduled' | 'sent';
@@ -452,6 +460,96 @@ describe('Post Tools — email/newsletter read surface', () => {
     const text = (result.content as { type: string; text: string }[])[0].text;
     expect(text).toContain('Newsletter');
     expect(text).toContain('weekly');
+    await c.close();
+  });
+});
+
+// ── Post Tools — email engagement metrics surface ──────
+
+describe('Post Tools — email engagement metrics', () => {
+  let client: Client;
+
+  beforeAll(async () => {
+    const ghost = createMockGhost({
+      email: {
+        id: 'e1',
+        status: 'submitted',
+        recipient_filter: 'all',
+        email_count: 11,
+        delivered_count: 10,
+        opened_count: 7,
+        failed_count: 1,
+      },
+      newsletter: { id: 'n1', name: 'Weekly', slug: 'weekly' },
+      email_segment: 'all',
+      status: 'published',
+    });
+    ({ client } = await setupMcpClient(ghost));
+  });
+
+  afterAll(async () => {
+    await client.close();
+  });
+
+  it('ghost_get_post surfaces engagement counts and rates', async () => {
+    const result = await client.callTool({
+      name: 'ghost_get_post',
+      arguments: { id: '507f1f77bcf86cd799439011' },
+    });
+    const text = (result.content as { type: string; text: string }[])[0].text;
+    expect(text).toContain('| Recipients | 11 |');
+    expect(text).toContain('| Delivered | 10 / 11 (90.9%) |');
+    expect(text).toContain('| Opened | 7 / 10 (70.0%) |');
+    expect(text).toContain('| Failed | 1 |');
+  });
+
+  it('ghost_get_post omits engagement rows when email object missing', async () => {
+    const ghost = createMockGhost();
+    const { client: c } = await setupMcpClient(ghost);
+    const result = await c.callTool({
+      name: 'ghost_get_post',
+      arguments: { id: '507f1f77bcf86cd799439011' },
+    });
+    const text = (result.content as { type: string; text: string }[])[0].text;
+    expect(text).not.toContain('Recipients');
+    expect(text).not.toContain('Delivered');
+    expect(text).not.toContain('Opened');
+    await c.close();
+  });
+
+  it('ghost_list_posts(show_email=true) shows Recip and Open% columns', async () => {
+    const result = await client.callTool({
+      name: 'ghost_list_posts',
+      arguments: { show_email: true },
+    });
+    const text = (result.content as { type: string; text: string }[])[0].text;
+    expect(text).toContain('Recip');
+    expect(text).toContain('Open%');
+    expect(text).toContain(' 11 ');  // email_count
+    expect(text).toContain('70%');    // opened/delivered = 7/10 = 70%
+  });
+
+  it('ghost_get_post handles zero delivered gracefully (avoids divide-by-zero)', async () => {
+    const ghost = createMockGhost({
+      email: {
+        id: 'e2',
+        status: 'submitting',
+        recipient_filter: 'all',
+        email_count: 100,
+        delivered_count: 0,
+        opened_count: 0,
+        failed_count: 0,
+      },
+    });
+    const { client: c } = await setupMcpClient(ghost);
+    const result = await c.callTool({
+      name: 'ghost_get_post',
+      arguments: { id: '507f1f77bcf86cd799439011' },
+    });
+    const text = (result.content as { type: string; text: string }[])[0].text;
+    expect(text).toContain('| Recipients | 100 |');
+    expect(text).toContain('| Delivered | 0 / 100 (0.0%) |');
+    expect(text).toContain('| Opened | 0 / 0 (-) |');
     await c.close();
   });
 });

--- a/src/tools/tools.test.ts
+++ b/src/tools/tools.test.ts
@@ -506,15 +506,18 @@ describe('Post Tools — email engagement metrics', () => {
   it('ghost_get_post omits engagement rows when email object missing', async () => {
     const ghost = createMockGhost();
     const { client: c } = await setupMcpClient(ghost);
-    const result = await c.callTool({
-      name: 'ghost_get_post',
-      arguments: { id: '507f1f77bcf86cd799439011' },
-    });
-    const text = (result.content as { type: string; text: string }[])[0].text;
-    expect(text).not.toContain('Recipients');
-    expect(text).not.toContain('Delivered');
-    expect(text).not.toContain('Opened');
-    await c.close();
+    try {
+      const result = await c.callTool({
+        name: 'ghost_get_post',
+        arguments: { id: '507f1f77bcf86cd799439011' },
+      });
+      const text = (result.content as { type: string; text: string }[])[0].text;
+      expect(text).not.toContain('Recipients');
+      expect(text).not.toContain('Delivered');
+      expect(text).not.toContain('Opened');
+    } finally {
+      await c.close();
+    }
   });
 
   it('ghost_list_posts(show_email=true) shows Recip and Open% columns', async () => {
@@ -542,15 +545,18 @@ describe('Post Tools — email engagement metrics', () => {
       },
     });
     const { client: c } = await setupMcpClient(ghost);
-    const result = await c.callTool({
-      name: 'ghost_get_post',
-      arguments: { id: '507f1f77bcf86cd799439011' },
-    });
-    const text = (result.content as { type: string; text: string }[])[0].text;
-    expect(text).toContain('| Recipients | 100 |');
-    expect(text).toContain('| Delivered | 0 / 100 (0.0%) |');
-    expect(text).toContain('| Opened | 0 / 0 (-) |');
-    await c.close();
+    try {
+      const result = await c.callTool({
+        name: 'ghost_get_post',
+        arguments: { id: '507f1f77bcf86cd799439011' },
+      });
+      const text = (result.content as { type: string; text: string }[])[0].text;
+      expect(text).toContain('| Recipients | 100 |');
+      expect(text).toContain('| Delivered | 0 / 100 (0.0%) |');
+      expect(text).toContain('| Opened | 0 / 0 (-) |');
+    } finally {
+      await c.close();
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

closes #23

PR #20(#19)이 newsletter 발송 **설정** 필드를 노출했지만 실제 **반응 지표** (open / delivered / failed)는 빠져 있어 "어떤 글이 잘 먹혔나" 정량 비교가 불가능했던 문제 해소. **별도 endpoint 호출 없이 기존 `?include=email,newsletter` 응답에 이미 포함된 통계 필드만 surface 확장**.

## Changes

### Type extension (`src/ghost/types.ts`)
`GhostEmail`에 다음 필드 추가:
- `opened_count` — 가장 핵심
- `uuid`, `error_data`, `subject`, `from`, `reply_to` — 메타
- `track_opens`, `track_clicks`, `feedback_enabled` — 추적 설정

### Read surface (`src/tools/post-tools.ts`)
**`ghost_get_post`** — `email.email_count`가 있을 때만 4행 자동 추가:
- `Recipients`: 발송 대상 수
- `Delivered`: 도착 수 / 대상 수 + 백분율
- `Opened`: 열어본 수 / 도착 수 + 백분율 (open rate)
- `Failed`: 실패 수

`delivered_count === 0` 같은 0-division 케이스는 `'-'`로 안전 fallback.

**`ghost_list_posts(show_email=true)`** — 두 컬럼 추가:
- `Recip`: 5자 폭, email_count
- `Open%`: 5자 폭, opened/delivered 백분율 정수

### Tests (4 신규)
- engagement 행이 정확히 표시 (90.9% / 70.0% 등 실 비율)
- email 객체 없을 때 행 자동 hide
- list 컬럼 정상 노출
- 0-division 안전 처리

### Dev tooling
- `scripts/verify-email-metrics.mjs` — embedded email 응답 vs 별도 endpoint 응답 비교 검증 스크립트. PR #20 패턴 재사용.

## Verification (실 인스턴스)

`scripts/verify-email-metrics.mjs`로 검증:

```
Found: prisma-extends-transaction-tenant-manual-injection (status=published)

embedded email keys (26):
  created_at, csd_email_count, delivered_count, email_count, error,
  error_data, failed_count, feedback_enabled, from, html, id, newsletter_id,
  opened_count, plaintext, post_id, recipient_filter, reply_to, source,
  source_type, status, subject, submitted_at, track_clicks, track_opens,
  updated_at, uuid

values:
  email_count: 11
  delivered_count: 10  (90.9%)
  opened_count: 7      (70.0% open rate)
  failed_count: 1
```

**`preview-tools.mjs`로 새 출력 확인 (실 데이터)**:

```
**Prisma $extends 테넌트 격리와 ...**

| Newsletter | default-newsletter |
| Email segment | all |
| Email status | submitted |
| Email recipient filter | all |
| Recipients | 11 |
| Delivered | 10 / 11 (90.9%) |
| Opened | 7 / 10 (70.0%) |
| Failed | 1 |
```

이슈 본문의 use case ("47개 scheduled 포스트 중 어떤 걸 발송할지 결정 시 과거 발송 데이터의 open rate 비교") MCP 단독으로 가능해짐.

## Out of scope (별도 이슈 권장)

이슈 본문 5번 항목 — `ghost_get_email_stats(post_id)` 신규 도구로 클릭 분포 등 detail 분석:
- 별도 endpoint `GET /admin/emails/:email_id/` 호출 필요
- 검증 시도 결과: **403 NoPermissionError** — Admin API 토큰으로는 emails endpoint 직접 접근 불가 (Ghost 권한 정책)
- 현재 토큰 권한 안에서는 구현 불가 → **별도 이슈로 분리 권장** (Staff Token 또는 다른 인증 방식 검토 필요)

## Test plan

- [x] `npm run build` — 통과
- [x] `npm test` — 121/121 (이전 117 + 신규 4)
- [x] 실 인스턴스 raw 응답 검증 (`scripts/verify-email-metrics.mjs`)
- [x] 실 인스턴스 도구 출력 미리보기 (`scripts/preview-tools.mjs`) — 새 4행 정상 노출
- [ ] **Reviewer 추가 검증 권장**: 다수의 sent 포스트가 있는 인스턴스에서 `ghost_list_posts(status: 'sent', show_email: true)` 호출 → Recip/Open% 컬럼 정렬/필터 use case 동작 확인