### PR TITLE
feat: publish to npm as @uppinote/ghost-mcp with auto-update setup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,14 +10,44 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write
 
     steps:
-      - name: Publish draft release
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build and test
+        run: |
+          npm run build
+          npm test
+
+      - name: Publish to npm
+        run: npm publish --access public --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Publish draft GitHub release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
           TAG: ${{ github.ref_name }}
         run: |
+          draft_count=$(gh release list --json isDraft -q '[.[] | select(.isDraft)] | length')
+          if [ "$draft_count" -gt 1 ]; then
+            echo "ERROR: multiple draft releases found ($draft_count). Manual cleanup required to avoid attaching wrong notes." >&2
+            exit 1
+          fi
+
           draft_tag=$(gh release list --json tagName,isDraft -q '.[] | select(.isDraft) | .tagName' | head -1)
 
           if [ -n "$draft_tag" ]; then

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,10 @@ npm test
 
 ## 구조
 
+- `src/cli.ts` - CLI entrypoint (args에 따라 `setup` | server 분기, npm bin)
+- `src/index.ts` - legacy server entry (v1.0.x/1.1.x 사용자 backward compat)
+- `src/setup.ts` - interactive setup wizard (Ghost URL/key 입력 → editor 등록 → npx 형태)
+- `src/server.ts` - MCP server 인스턴스화 + 도구 등록
 - `src/config.ts` - 환경변수 로딩 + HTTPS/API 키 검증
 - `src/validation.ts` - 입력값 검증 (ghostId, safeSlug, path traversal 방지)
 - `src/ghost/client.ts` - Ghost Admin API 클라이언트 (JWT 인증, 에러 정규화)
@@ -23,7 +27,14 @@ npm test
 ## 환경변수
 
 `GHOST_URL`, `GHOST_ADMIN_API_KEY` — MCP 클라이언트 설정의 `env` 필드로 전달.
-`npm run setup`으로 자동 등록 가능.
+사용자: `npx -y @uppinote/ghost-mcp@latest setup` 으로 자동 등록 (또는 dev clone 후 `npm run setup`).
+
+## 배포
+
+- npm: `@uppinote/ghost-mcp` (public, scoped). v1.2.0+
+- 사용자 등록 형식: `"command": "npx", "args": ["-y", "@uppinote/ghost-mcp@latest"]`
+- Tag push 시 `.github/workflows/release.yml`이 npm publish + GitHub Release publish 자동 처리
+- 필요 secret: `NPM_TOKEN` (Granular Access Token, scope `@uppinote`, Read & Write, 2FA bypass)
 
 ## 패키지 매니저
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,13 +58,13 @@ npm (package-lock.json)
 | 찾는 것 | HANDBOOK 섹션 |
 |---------|---------------|
 | 모듈 의존 방향 | 1.2 |
-| MCP 부트스트랩 / Server Instructions | 2 |
+| MCP 부트스트랩 / Server Instructions / Setup wizard | 2 |
 | JWT 토큰 / 에러 정규화 / Lazy-include | 3 |
 | Post/Page 타입 분리 | 4 |
 | Zod schema + 표 출력 / Optimistic locking / Empty-input guard | 5 |
 | 검증 (ghostId, safeSlug, path traversal) / JWT 보안 | 6 |
 | 마크다운 포맷 자동 감지 / Sync index / Lexical vs Mobiledoc | 7 |
-| InMemoryTransport / fetch mock / 양방향 마커 | 8 |
+| InMemoryTransport / fetch mock / Testable module 설계 / 양방향 마커 | 8 |
 
 ### Boilerplate Reference
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 uppinote
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -16,14 +16,10 @@ Create, edit, publish, and sync blog posts directly from Claude Code, Cursor, or
 ## Quick Start
 
 ```bash
-git clone https://github.com/uppinote20/ghost-mcp.git
-cd ghost-mcp
-npm install
-npm run build
-npm run setup
+npx -y @uppinote/ghost-mcp@latest setup
 ```
 
-The setup wizard registers the server in your editor:
+The setup wizard registers the server in your editor and prompts for the Ghost URL + Admin API Key:
 
 ```
 ┌  ghost-mcp setup
@@ -42,7 +38,13 @@ The setup wizard registers the server in your editor:
 └  Restart your editor to activate.
 ```
 
-> If you run `npm run setup`, you'll see a one-time prompt to star this repo. You can always skip it. Pass `--yes` to skip the prompt, or `--star` to star without asking.
+After setup, your editor is registered with `npx -y @uppinote/ghost-mcp@latest`, so you'll automatically pick up new releases on the next start (npm cache TTL ~24h).
+
+> The setup wizard shows a one-time GitHub star prompt. Pass `--yes` to skip the prompt, or `--star` to star without asking.
+
+## Updating
+
+Because the editor is registered with `npx -y ...@latest`, restarts pick up new versions automatically. To force-refresh immediately, clear npm's npx cache or restart the editor twice.
 
 ## Manual Setup
 
@@ -52,8 +54,8 @@ If you prefer to configure manually, add to your MCP settings:
 {
   "mcpServers": {
     "ghost-blog": {
-      "command": "node",
-      "args": ["/absolute/path/to/ghost-mcp/dist/index.js"],
+      "command": "npx",
+      "args": ["-y", "@uppinote/ghost-mcp@latest"],
       "env": {
         "GHOST_URL": "https://your-blog.com",
         "GHOST_ADMIN_API_KEY": "your_id:your_hex_secret"
@@ -67,6 +69,25 @@ If you prefer to configure manually, add to your MCP settings:
 |--------|--------------|
 | Claude Code | `~/.claude/settings.json` |
 | Cursor | `~/.cursor/mcp.json` |
+
+## Migrating from v1.0.x / v1.1.x
+
+Earlier versions registered the server with `node /path/to/dist/index.js`, which doesn't auto-update. To switch to the npx flow:
+
+1. Run `npx -y @uppinote/ghost-mcp@latest setup` and choose "overwrite" when it detects the existing entry.
+2. Restart your editor.
+3. (Optional) Delete the old `git clone` directory.
+
+## Development (contributors)
+
+```bash
+git clone https://github.com/uppinote20/ghost-mcp.git
+cd ghost-mcp
+npm install
+npm run build
+npm run setup    # registers from local dist via the same wizard
+npm test
+```
 
 ### Getting Your API Key
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,21 @@
 {
-  "name": "ghost-mcp",
-  "version": "1.1.0",
+  "name": "@uppinote/ghost-mcp",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "ghost-mcp",
-      "version": "1.1.0",
+      "name": "@uppinote/ghost-mcp",
+      "version": "1.2.0",
+      "license": "MIT",
       "dependencies": {
+        "@clack/prompts": "^1.2.0",
         "@modelcontextprotocol/sdk": "^1.20.0"
       },
+      "bin": {
+        "ghost-mcp": "dist/cli.js"
+      },
       "devDependencies": {
-        "@clack/prompts": "^1.2.0",
         "@types/node": "^22.0.0",
         "typescript": "^5.5.0",
         "vitest": "^4.1.2"
@@ -21,7 +25,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@clack/core/-/core-1.2.0.tgz",
       "integrity": "sha512-qfxof/3T3t9DPU/Rj3OmcFyZInceqj/NVtO9rwIuJqCUgh32gwPjpFQQp/ben07qKlhpwq7GzfWpST4qdJ5Drg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-wrap-ansi": "^0.1.3",
@@ -32,7 +35,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@clack/prompts/-/prompts-1.2.0.tgz",
       "integrity": "sha512-4jmztR9fMqPMjz6H/UZXj0zEmE43ha1euENwkckKKel4XpSfokExPo5AiVStdHSAlHekz4d0CA/r45Ok1E4D3w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@clack/core": "1.2.0",
@@ -1029,14 +1031,12 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-1.2.1.tgz",
       "integrity": "sha512-Q9acT/+Uu3GwGj+5w/zsGuQjh9O1TyywhIwAxHudtWrgF09nHOPrvTLhQevPbttcxjr/SNN7mJmfOw/B1bXgow==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-string-width": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fast-string-width/-/fast-string-width-1.1.0.tgz",
       "integrity": "sha512-O3fwIVIH5gKB38QNbdg+3760ZmGz0SZMgvwJbA1b2TGXceKE6A2cOlfogh1iw8lr049zPyd7YADHy+B7U4W9bQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-string-truncated-width": "^1.2.0"
@@ -1062,7 +1062,6 @@
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.1.6.tgz",
       "integrity": "sha512-HlUwET7a5gqjURj70D5jl7aC3Zmy4weA1SHUfM0JFI0Ptq987NH2TwbBFLoERhfwk+E+eaq4EK3jXoT+R3yp3w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-string-width": "^1.1.0"
@@ -2102,7 +2101,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/source-map-js": {

--- a/package.json
+++ b/package.json
@@ -1,22 +1,52 @@
 {
-  "name": "ghost-mcp",
-  "version": "1.1.0",
+  "name": "@uppinote/ghost-mcp",
+  "version": "1.2.0",
   "description": "Ghost Blog Management MCP Server",
   "type": "module",
-  "main": "dist/index.js",
+  "main": "dist/cli.js",
+  "bin": {
+    "ghost-mcp": "./dist/cli.js"
+  },
+  "files": [
+    "dist/**/*.js",
+    "README.md",
+    ".env.example"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/uppinote20/ghost-mcp.git"
+  },
+  "homepage": "https://github.com/uppinote20/ghost-mcp",
+  "bugs": {
+    "url": "https://github.com/uppinote20/ghost-mcp/issues"
+  },
+  "license": "MIT",
+  "keywords": [
+    "mcp",
+    "ghost",
+    "ghost-cms",
+    "blog",
+    "claude",
+    "cursor",
+    "model-context-protocol"
+  ],
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && chmod +x dist/cli.js",
     "dev": "tsc --watch",
-    "start": "node dist/index.js",
+    "start": "node dist/cli.js",
     "test": "vitest run",
     "test:watch": "vitest",
-    "setup": "node scripts/setup.mjs"
+    "setup": "node dist/cli.js setup",
+    "prepublishOnly": "npm run build && npm test"
   },
   "dependencies": {
+    "@clack/prompts": "^1.2.0",
     "@modelcontextprotocol/sdk": "^1.20.0"
   },
   "devDependencies": {
-    "@clack/prompts": "^1.2.0",
     "@types/node": "^22.0.0",
     "typescript": "^5.5.0",
     "vitest": "^4.1.2"

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -1,0 +1,43 @@
+/** @covers src/cli.ts */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { main } from './cli.js';
+
+describe('cli main()', () => {
+  let stderrSpy: ReturnType<typeof vi.spyOn>;
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    exitSpy = vi
+      .spyOn(process, 'exit')
+      .mockImplementation((code?: number | string | null | undefined) => {
+        throw new Error(`__exit__:${code}`);
+      });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('exits 1 with stderr message on unknown subcommand', async () => {
+    await expect(main(['node', 'cli.js', 'bogus'])).rejects.toThrow('__exit__:1');
+    expect(stderrSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Unknown subcommand: bogus')
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it('formats subcommand name in stderr message', async () => {
+    await expect(main(['node', 'cli.js', 'foo bar'])).rejects.toThrow();
+    expect(stderrSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Unknown subcommand: foo bar')
+    );
+  });
+
+  it('mentions allowed subcommand "setup" in stderr usage hint', async () => {
+    await expect(main(['node', 'cli.js', 'typo'])).rejects.toThrow();
+    expect(stderrSpy).toHaveBeenCalledWith(
+      expect.stringContaining('ghost-mcp [setup]')
+    );
+  });
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+/**
+ * ghost-mcp CLI entry.
+ *
+ * Modes:
+ *   ghost-mcp           → start MCP server over stdio (default — invoked by editors)
+ *   ghost-mcp setup     → interactive setup wizard (one-time, registers in editor config)
+ *
+ * @handbook 2.1-mcp-bootstrap
+ */
+const sub = process.argv[2];
+
+if (sub === 'setup') {
+  const { runSetup } = await import('./setup.js');
+  await runSetup();
+} else if (sub !== undefined) {
+  process.stderr.write(`Unknown subcommand: ${sub}. Usage: ghost-mcp [setup]\n`);
+  process.exit(1);
+} else {
+  const { StdioServerTransport } = await import(
+    '@modelcontextprotocol/sdk/server/stdio.js'
+  );
+  const { loadConfig } = await import('./config.js');
+  const { createServer } = await import('./server.js');
+
+  const config = loadConfig();
+  const server = createServer(config);
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,24 +7,51 @@
  *   ghost-mcp setup     → interactive setup wizard (one-time, registers in editor config)
  *
  * @handbook 2.1-mcp-bootstrap
+ * @tested src/cli.test.ts
  */
-const sub = process.argv[2];
+import { fileURLToPath } from 'node:url';
+import { realpathSync } from 'node:fs';
 
-if (sub === 'setup') {
-  const { runSetup } = await import('./setup.js');
-  await runSetup();
-} else if (sub !== undefined) {
-  process.stderr.write(`Unknown subcommand: ${sub}. Usage: ghost-mcp [setup]\n`);
-  process.exit(1);
-} else {
-  const { StdioServerTransport } = await import(
-    '@modelcontextprotocol/sdk/server/stdio.js'
-  );
-  const { loadConfig } = await import('./config.js');
-  const { createServer } = await import('./server.js');
+export async function main(argv: string[] = process.argv): Promise<void> {
+  const sub = argv[2];
 
-  const config = loadConfig();
-  const server = createServer(config);
-  const transport = new StdioServerTransport();
-  await server.connect(transport);
+  if (sub === 'setup') {
+    const { runSetup } = await import('./setup.js');
+    await runSetup();
+  } else if (sub !== undefined) {
+    process.stderr.write(`Unknown subcommand: ${sub}. Usage: ghost-mcp [setup]\n`);
+    process.exit(1);
+  } else {
+    // Parallel dynamic imports — server-mode hot path on every editor restart.
+    const [
+      { StdioServerTransport },
+      { loadConfig },
+      { createServer },
+    ] = await Promise.all([
+      import('@modelcontextprotocol/sdk/server/stdio.js'),
+      import('./config.js'),
+      import('./server.js'),
+    ]);
+
+    const config = loadConfig();
+    const server = createServer(config);
+    const transport = new StdioServerTransport();
+    await server.connect(transport);
+  }
+}
+
+// Detect "invoked as main module" — survives npm/npx symlinks and Windows
+// drive-letter URLs by canonicalising both sides through realpath +
+// fileURLToPath. Plain string comparison of import.meta.url against
+// `file://${process.argv[1]}` would break in those cases.
+function isMainModule(): boolean {
+  try {
+    return realpathSync(fileURLToPath(import.meta.url)) === realpathSync(process.argv[1]);
+  } catch {
+    return false;
+  }
+}
+
+if (isMainModule()) {
+  await main();
 }

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -49,12 +49,12 @@ describe('loadConfig', () => {
 
   it('rejects HTTP for non-localhost', () => {
     process.env.GHOST_URL = 'http://blog.example.com';
-    expect(() => loadConfig()).toThrow('GHOST_URL must use HTTPS');
+    expect(() => loadConfig()).toThrow('GHOST_URL:');
   });
 
   it('rejects HTTP for public IP', () => {
     process.env.GHOST_URL = 'http://203.0.113.50:2368';
-    expect(() => loadConfig()).toThrow('GHOST_URL must use HTTPS');
+    expect(() => loadConfig()).toThrow('GHOST_URL:');
   });
 
   // ── API key format ──

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -81,8 +81,13 @@ describe('loadConfig', () => {
   });
 
   it('rejects key with non-hex secret', () => {
-    process.env.GHOST_ADMIN_API_KEY = 'aaaaaaaaaaaa:not-hex-value!';
+    process.env.GHOST_ADMIN_API_KEY = 'abcdef1234567890abcdef12:not-hex-value!';
     expect(() => loadConfig()).toThrow('hex-encoded');
+  });
+
+  it('rejects key with non-hex id', () => {
+    process.env.GHOST_ADMIN_API_KEY = 'badid:abcdef0123456789';
+    expect(() => loadConfig()).toThrow('24-character hex');
   });
 
   it('rejects key with multiple colons', () => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,6 +2,8 @@
  * @tested src/config.test.ts
  * @handbook 2.3-config-validation
  */
+import { checkGhostUrl, checkGhostKey } from './validation.js';
+
 export interface Config {
   ghostUrl: string;
   ghostAdminApiKey: string;
@@ -17,22 +19,11 @@ export function loadConfig(): Config {
     );
   }
 
-  const parsed = new URL(ghostUrl);
-  if (
-    parsed.protocol !== 'https:' &&
-    parsed.hostname !== 'localhost' &&
-    parsed.hostname !== '127.0.0.1'
-  ) {
-    throw new Error('GHOST_URL must use HTTPS (except for localhost)');
-  }
+  const urlError = checkGhostUrl(ghostUrl);
+  if (urlError) throw new Error(`GHOST_URL: ${urlError}`);
 
-  const keyParts = ghostAdminApiKey.split(':');
-  if (keyParts.length !== 2 || !keyParts[0] || !keyParts[1]) {
-    throw new Error('GHOST_ADMIN_API_KEY must be in "id:secret" format');
-  }
-  if (!/^[a-f0-9]+$/.test(keyParts[1])) {
-    throw new Error('GHOST_ADMIN_API_KEY secret must be hex-encoded');
-  }
+  const keyError = checkGhostKey(ghostAdminApiKey);
+  if (keyError) throw new Error(`GHOST_ADMIN_API_KEY: ${keyError}`);
 
   return { ghostUrl, ghostAdminApiKey };
 }

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -11,6 +11,8 @@
  *   --yes               non-interactive; skips star prompt
  *   --star              star without prompting (dotfiles / CI consent)
  *   --force-star-prompt re-ask even if already prompted
+ *
+ * @handbook 2.4-setup-wizard
  */
 import fs from 'fs';
 import os from 'os';
@@ -29,17 +31,11 @@ import {
   spinner,
   log,
 } from '@clack/prompts';
+import { checkGhostUrl, checkGhostKey } from './validation.js';
 
 const REPO = 'uppinote20/ghost-mcp';
 const REPO_URL = `https://github.com/${REPO}`;
 const NPM_PACKAGE = '@uppinote/ghost-mcp';
-
-// ── Flags ────────────────────────────────────────
-
-const ARGS = new Set(process.argv.slice(2));
-const FLAG_YES = ARGS.has('--yes');
-const FLAG_STAR = ARGS.has('--star');
-const FLAG_FORCE_STAR_PROMPT = ARGS.has('--force-star-prompt');
 
 // ── Editor config paths ─────────────────────────
 
@@ -129,19 +125,25 @@ function tryStar(): void {
   }
 }
 
-async function offerStar(): Promise<void> {
+interface StarFlags {
+  yes: boolean;
+  star: boolean;
+  forceStarPrompt: boolean;
+}
+
+async function offerStar(flags: StarFlags): Promise<void> {
   // --star: explicit opt-in, no prompt (dotfiles / CI consent)
-  if (FLAG_STAR) {
+  if (flags.star) {
     tryStar();
     markStarPrompted();
     return;
   }
 
   // --yes: non-interactive; star is always prompt-only, so skip
-  if (FLAG_YES) return;
+  if (flags.yes) return;
 
   // Already asked once; stay quiet unless user forces re-prompt
-  if (fs.existsSync(STAR_MARKER) && !FLAG_FORCE_STAR_PROMPT) return;
+  if (fs.existsSync(STAR_MARKER) && !flags.forceStarPrompt) return;
 
   // Mark before prompting so Ctrl+C is treated as "No" — prevents re-asking
   // on the next run when setup itself already succeeded.
@@ -161,6 +163,13 @@ async function offerStar(): Promise<void> {
 // ── Main ─────────────────────────────────────────
 
 export async function runSetup(): Promise<void> {
+  // Parse flags lazily so importing this module (e.g. from tests) has no
+  // process.argv side-effects.
+  const args = new Set(process.argv.slice(2));
+  const flagYes = args.has('--yes');
+  const flagStar = args.has('--star');
+  const flagForceStarPrompt = args.has('--force-star-prompt');
+
   intro('ghost-mcp setup');
 
   // 1. Ghost URL
@@ -168,21 +177,7 @@ export async function runSetup(): Promise<void> {
     await text({
       message: 'Ghost blog URL',
       placeholder: 'https://your-blog.com',
-      validate: (v) => {
-        if (!v) return 'URL is required';
-        try {
-          const u = new URL(v);
-          if (
-            u.protocol !== 'https:' &&
-            !['localhost', '127.0.0.1'].includes(u.hostname)
-          ) {
-            return 'Must use HTTPS (except localhost)';
-          }
-        } catch {
-          return 'Invalid URL';
-        }
-        return undefined;
-      },
+      validate: checkGhostUrl,
     })
   );
 
@@ -191,17 +186,7 @@ export async function runSetup(): Promise<void> {
     await password({
       message: 'Admin API Key (Ghost → Settings → Integrations)',
       mask: '*',
-      validate: (v) => {
-        if (!v) return 'API key is required';
-        const parts = v.split(':');
-        if (parts.length !== 2 || !parts[0] || !parts[1]) {
-          return 'Must be in "id:secret" format';
-        }
-        if (!/^[a-f0-9]+$/.test(parts[1])) {
-          return 'Secret must be hex-encoded';
-        }
-        return undefined;
-      },
+      validate: checkGhostKey,
     })
   );
 
@@ -234,7 +219,7 @@ export async function runSetup(): Promise<void> {
       JSON.stringify({ mcpServers: { 'ghost-blog': serverConfig } }, null, 2),
       'Add this to your MCP config'
     );
-    await offerStar();
+    await offerStar({ yes: flagYes, star: flagStar, forceStarPrompt: flagForceStarPrompt });
     outro('Copy the config above to your editor settings.');
     return;
   }
@@ -279,7 +264,7 @@ export async function runSetup(): Promise<void> {
     'ghost-blog registered'
   );
 
-  await offerStar();
+  await offerStar({ yes: flagYes, star: flagStar, forceStarPrompt: flagForceStarPrompt });
 
   outro(`Restart ${EDITORS[editor].label} to activate the MCP server.`);
 }

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -1,17 +1,19 @@
-#!/usr/bin/env node
-
 /**
  * Interactive setup for ghost-mcp.
- * Registers the MCP server in your editor's config.
+ * Registers the MCP server in your editor's config using `npx -y` invocation
+ * so the editor always picks up the latest published version.
  *
- * Usage:
- *   npm run setup
- *   npm run setup -- --yes    # non-interactive; skips star prompt
- *   npm run setup -- --star   # star without prompting (dotfiles/CI opt-in)
- *   npm run setup -- --force-star-prompt  # re-ask even if already prompted
+ * Invoked via:
+ *   npx -y @uppinote/ghost-mcp@latest setup
+ *   npm run setup            (dev: same code path, just a shorter alias)
+ *
+ * Flags:
+ *   --yes               non-interactive; skips star prompt
+ *   --star              star without prompting (dotfiles / CI consent)
+ *   --force-star-prompt re-ask even if already prompted
  */
-
 import fs from 'fs';
+import os from 'os';
 import path from 'path';
 import { spawnSync } from 'child_process';
 import {
@@ -30,6 +32,7 @@ import {
 
 const REPO = 'uppinote20/ghost-mcp';
 const REPO_URL = `https://github.com/${REPO}`;
+const NPM_PACKAGE = '@uppinote/ghost-mcp';
 
 // ── Flags ────────────────────────────────────────
 
@@ -40,10 +43,13 @@ const FLAG_FORCE_STAR_PROMPT = ARGS.has('--force-star-prompt');
 
 // ── Editor config paths ─────────────────────────
 
-const HOME = process.env.HOME || '~';
+const HOME = os.homedir();
 const STAR_MARKER = path.join(HOME, '.config', 'ghost-mcp', '.star-prompted');
 
-const EDITORS = {
+const EDITORS: Record<
+  string,
+  { label: string; path: string | null; key: string }
+> = {
   'claude-code': {
     label: 'Claude Code',
     path: path.join(HOME, '.claude', 'settings.json'),
@@ -63,27 +69,32 @@ const EDITORS = {
 
 // ── Helpers ──────────────────────────────────────
 
-function bail(msg) {
+function bail(msg: string): never {
   cancel(msg);
   process.exit(0);
 }
 
-function check(value) {
-  if (isCancel(value)) bail('Setup cancelled.');
-  return value;
+function bailError(msg: string): never {
+  cancel(msg);
+  process.exit(1);
 }
 
-function ghAvailable() {
+function check<T>(value: T | symbol): T {
+  if (isCancel(value)) bail('Setup cancelled.');
+  return value as T;
+}
+
+function ghAvailable(): boolean {
   const r = spawnSync('gh', ['--version'], { stdio: 'ignore' });
   return r.status === 0;
 }
 
-function ghAuthed() {
+function ghAuthed(): boolean {
   const r = spawnSync('gh', ['auth', 'status'], { stdio: 'ignore' });
   return r.status === 0;
 }
 
-function markStarPrompted() {
+function markStarPrompted(): void {
   try {
     fs.mkdirSync(path.dirname(STAR_MARKER), { recursive: true });
     fs.writeFileSync(STAR_MARKER, '');
@@ -92,7 +103,7 @@ function markStarPrompted() {
   }
 }
 
-function tryStar() {
+function tryStar(): void {
   if (!ghAvailable()) {
     log.info(`\`gh\` CLI not found. Star manually at:\n  ${REPO_URL}`);
     return;
@@ -105,8 +116,7 @@ function tryStar() {
   }
 
   // `gh repo star` subcommand does not exist. Use the REST API directly:
-  // PUT /user/starred/{owner}/{repo} — stderr is suppressed so gh's failure
-  // output does not leak into the setup UI.
+  // PUT /user/starred/{owner}/{repo}.
   const r = spawnSync(
     'gh',
     ['api', '--method', 'PUT', '--silent', `/user/starred/${REPO}`],
@@ -119,7 +129,7 @@ function tryStar() {
   }
 }
 
-async function offerStar() {
+async function offerStar(): Promise<void> {
   // --star: explicit opt-in, no prompt (dotfiles / CI consent)
   if (FLAG_STAR) {
     tryStar();
@@ -144,32 +154,16 @@ async function offerStar() {
     initialValue: false,
   });
 
-  // Ctrl+C here = "no thanks, skip the star". Setup already succeeded, so
-  // don't use check()/bail() which would print "Setup cancelled."
   if (isCancel(yes)) return;
-
   if (yes) tryStar();
 }
 
 // ── Main ─────────────────────────────────────────
 
-async function main() {
+export async function runSetup(): Promise<void> {
   intro('ghost-mcp setup');
 
-  // 1. Check build
-  const serverPath = path.resolve(
-    path.dirname(new URL(import.meta.url).pathname),
-    '..',
-    'dist',
-    'index.js'
-  );
-
-  if (!fs.existsSync(serverPath)) {
-    log.error(`Server not built. Run "npm run build" first.`);
-    bail('Build required');
-  }
-
-  // 2. Ghost URL
+  // 1. Ghost URL
   const ghostUrl = check(
     await text({
       message: 'Ghost blog URL',
@@ -178,17 +172,21 @@ async function main() {
         if (!v) return 'URL is required';
         try {
           const u = new URL(v);
-          if (u.protocol !== 'https:' && !['localhost', '127.0.0.1'].includes(u.hostname)) {
+          if (
+            u.protocol !== 'https:' &&
+            !['localhost', '127.0.0.1'].includes(u.hostname)
+          ) {
             return 'Must use HTTPS (except localhost)';
           }
         } catch {
           return 'Invalid URL';
         }
+        return undefined;
       },
     })
   );
 
-  // 3. Admin API Key
+  // 2. Admin API Key
   const apiKey = check(
     await password({
       message: 'Admin API Key (Ghost → Settings → Integrations)',
@@ -202,11 +200,12 @@ async function main() {
         if (!/^[a-f0-9]+$/.test(parts[1])) {
           return 'Secret must be hex-encoded';
         }
+        return undefined;
       },
     })
   );
 
-  // 4. Editor selection
+  // 3. Editor selection
   const editor = check(
     await select({
       message: 'Register in',
@@ -216,19 +215,20 @@ async function main() {
         { value: 'print', label: 'Print config (manual setup)' },
       ],
     })
-  );
+  ) as string;
 
-  // 5. Build MCP config
+  // 4. Build MCP config — uses `npx -y` so the editor always pulls the latest
+  //    published version on next start (npm cache TTL is ~24h).
   const serverConfig = {
-    command: 'node',
-    args: [serverPath],
+    command: 'npx',
+    args: ['-y', `${NPM_PACKAGE}@latest`],
     env: {
       GHOST_URL: ghostUrl.replace(/\/$/, ''),
       GHOST_ADMIN_API_KEY: apiKey,
     },
   };
 
-  // 6. Print or write
+  // 5. Print or write
   if (editor === 'print') {
     note(
       JSON.stringify({ mcpServers: { 'ghost-blog': serverConfig } }, null, 2),
@@ -240,21 +240,21 @@ async function main() {
   }
 
   const { path: settingsPath, key } = EDITORS[editor];
+  if (!settingsPath) bailError('Internal: editor has no settings path');
 
   // Read existing settings
-  let settings = {};
+  let settings: Record<string, Record<string, unknown>> = {};
   if (fs.existsSync(settingsPath)) {
     try {
       settings = JSON.parse(fs.readFileSync(settingsPath, 'utf-8'));
     } catch {
       log.error(`Failed to parse ${settingsPath}`);
-      bail('Fix the file manually and retry');
+      bailError('Fix the file manually and retry');
     }
   }
 
   if (!settings[key]) settings[key] = {};
 
-  // Check for existing entry
   if (settings[key]['ghost-blog']) {
     const overwrite = check(
       await confirm({
@@ -265,7 +265,6 @@ async function main() {
     if (!overwrite) bail('Keeping existing config');
   }
 
-  // Write
   const s = spinner();
   s.start('Writing config');
 
@@ -276,7 +275,7 @@ async function main() {
   s.stop('Config saved');
 
   note(
-    `Server: ${serverPath}\nGhost:  ${ghostUrl}`,
+    `Package: ${NPM_PACKAGE}@latest (auto-updated by npx)\nGhost:   ${ghostUrl}`,
     'ghost-blog registered'
   );
 
@@ -284,8 +283,3 @@ async function main() {
 
   outro(`Restart ${EDITORS[editor].label} to activate the MCP server.`);
 }
-
-main().catch((err) => {
-  log.error(err.message);
-  process.exit(1);
-});

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -203,12 +203,14 @@ export async function runSetup(): Promise<void> {
   ) as string;
 
   // 4. Build MCP config — uses `npx -y` so the editor always pulls the latest
-  //    published version on next start (npm cache TTL is ~24h).
+  //    published version on next start (npm cache TTL is ~24h). Normalise URL
+  //    once so the success note and the saved config show the same value.
+  const normalisedUrl = ghostUrl.replace(/\/$/, '');
   const serverConfig = {
     command: 'npx',
     args: ['-y', `${NPM_PACKAGE}@latest`],
     env: {
-      GHOST_URL: ghostUrl.replace(/\/$/, ''),
+      GHOST_URL: normalisedUrl,
       GHOST_ADMIN_API_KEY: apiKey,
     },
   };
@@ -260,7 +262,7 @@ export async function runSetup(): Promise<void> {
   s.stop('Config saved');
 
   note(
-    `Package: ${NPM_PACKAGE}@latest (auto-updated by npx)\nGhost:   ${ghostUrl}`,
+    `Package: ${NPM_PACKAGE}@latest (auto-updated by npx)\nGhost:   ${normalisedUrl}`,
     'ghost-blog registered'
   );
 

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -198,9 +198,9 @@ export async function runSetup(): Promise<void> {
         { value: 'claude-code', label: 'Claude Code', hint: '~/.claude/settings.json' },
         { value: 'cursor', label: 'Cursor', hint: '~/.cursor/mcp.json' },
         { value: 'print', label: 'Print config (manual setup)' },
-      ],
+      ] as const,
     })
-  ) as string;
+  );
 
   // 4. Build MCP config — uses `npx -y` so the editor always pulls the latest
   //    published version on next start (npm cache TTL is ~24h). Normalise URL

--- a/src/validation.test.ts
+++ b/src/validation.test.ts
@@ -202,6 +202,8 @@ describe('checkGhostUrl', () => {
 // ── checkGhostKey ─────────────────────────────────────────
 
 describe('checkGhostKey', () => {
+  const validId = '507f1f77bcf86cd799439011';
+
   it('rejects empty input', () => {
     expect(checkGhostKey('')).toBe('API key is required');
     expect(checkGhostKey(undefined)).toBe('API key is required');
@@ -213,16 +215,28 @@ describe('checkGhostKey', () => {
 
   it('rejects empty id or secret around colon', () => {
     expect(checkGhostKey(':abc')).toBe('Must be in "id:secret" format');
-    expect(checkGhostKey('id:')).toBe('Must be in "id:secret" format');
+    expect(checkGhostKey(`${validId}:`)).toBe('Must be in "id:secret" format');
+  });
+
+  it('rejects id that is not 24-char hex', () => {
+    expect(checkGhostKey('badvalue:abcdef0123456789')).toBe(
+      'ID must be a 24-character hex string'
+    );
+    expect(checkGhostKey('5f1a2b:abcdef0123456789')).toBe(
+      'ID must be a 24-character hex string'
+    );
+    expect(checkGhostKey('507F1F77BCF86CD799439011:abc')).toBe(
+      'ID must be a 24-character hex string'
+    );
   });
 
   it('rejects non-hex secret', () => {
-    expect(checkGhostKey('id:not-hex-zzz!')).toBe(
+    expect(checkGhostKey(`${validId}:not-hex-zzz!`)).toBe(
       'Secret must be hex-encoded'
     );
   });
 
-  it('accepts valid id:hex format', () => {
-    expect(checkGhostKey('5f1a2b:abcdef0123456789')).toBeUndefined();
+  it('accepts valid 24-char-hex id with hex secret', () => {
+    expect(checkGhostKey(`${validId}:abcdef0123456789`)).toBeUndefined();
   });
 });

--- a/src/validation.test.ts
+++ b/src/validation.test.ts
@@ -1,7 +1,14 @@
 /** @covers src/validation.ts */
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import path from 'path';
-import { ghostId, safeSlug, validateSyncPath, audit } from './validation.js';
+import {
+  ghostId,
+  safeSlug,
+  validateSyncPath,
+  audit,
+  checkGhostUrl,
+  checkGhostKey,
+} from './validation.js';
 
 // ── ghostId ──────────────────────────────────────────────
 
@@ -161,5 +168,61 @@ describe('audit', () => {
     const output = JSON.parse(spy.mock.calls[0][0] as string);
     expect(() => new Date(output.ts)).not.toThrow();
     expect(new Date(output.ts).toISOString()).toBe(output.ts);
+  });
+});
+
+// ── checkGhostUrl ─────────────────────────────────────────
+
+describe('checkGhostUrl', () => {
+  it('rejects empty input', () => {
+    expect(checkGhostUrl('')).toBe('URL is required');
+    expect(checkGhostUrl(undefined)).toBe('URL is required');
+  });
+
+  it('rejects http for non-localhost', () => {
+    expect(checkGhostUrl('http://blog.example.com')).toBe(
+      'Must use HTTPS (except localhost)'
+    );
+  });
+
+  it('accepts https', () => {
+    expect(checkGhostUrl('https://blog.example.com')).toBeUndefined();
+  });
+
+  it('accepts http for localhost / 127.0.0.1', () => {
+    expect(checkGhostUrl('http://localhost:2368')).toBeUndefined();
+    expect(checkGhostUrl('http://127.0.0.1:2368')).toBeUndefined();
+  });
+
+  it('rejects malformed URLs', () => {
+    expect(checkGhostUrl('not-a-url')).toBe('Invalid URL');
+  });
+});
+
+// ── checkGhostKey ─────────────────────────────────────────
+
+describe('checkGhostKey', () => {
+  it('rejects empty input', () => {
+    expect(checkGhostKey('')).toBe('API key is required');
+    expect(checkGhostKey(undefined)).toBe('API key is required');
+  });
+
+  it('rejects missing colon separator', () => {
+    expect(checkGhostKey('justanid')).toBe('Must be in "id:secret" format');
+  });
+
+  it('rejects empty id or secret around colon', () => {
+    expect(checkGhostKey(':abc')).toBe('Must be in "id:secret" format');
+    expect(checkGhostKey('id:')).toBe('Must be in "id:secret" format');
+  });
+
+  it('rejects non-hex secret', () => {
+    expect(checkGhostKey('id:not-hex-zzz!')).toBe(
+      'Secret must be hex-encoded'
+    );
+  });
+
+  it('accepts valid id:hex format', () => {
+    expect(checkGhostKey('5f1a2b:abcdef0123456789')).toBeUndefined();
   });
 });

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -47,3 +47,38 @@ export function audit(
     })
   );
 }
+
+/**
+ * Pure-function checks used by both the boundary loader (config.ts) and the
+ * setup wizard prompts (setup.ts). Return undefined on valid input, an error
+ * message on invalid. Single source of truth — keeps the rules and messages
+ * from drifting between server-startup validation and the interactive UI.
+ */
+export function checkGhostUrl(v: string | undefined): string | undefined {
+  if (!v) return 'URL is required';
+  let parsed: URL;
+  try {
+    parsed = new URL(v);
+  } catch {
+    return 'Invalid URL';
+  }
+  if (
+    parsed.protocol !== 'https:' &&
+    !['localhost', '127.0.0.1'].includes(parsed.hostname)
+  ) {
+    return 'Must use HTTPS (except localhost)';
+  }
+  return undefined;
+}
+
+export function checkGhostKey(v: string | undefined): string | undefined {
+  if (!v) return 'API key is required';
+  const parts = v.split(':');
+  if (parts.length !== 2 || !parts[0] || !parts[1]) {
+    return 'Must be in "id:secret" format';
+  }
+  if (!/^[a-f0-9]+$/.test(parts[1])) {
+    return 'Secret must be hex-encoded';
+  }
+  return undefined;
+}

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -77,6 +77,11 @@ export function checkGhostKey(v: string | undefined): string | undefined {
   if (parts.length !== 2 || !parts[0] || !parts[1]) {
     return 'Must be in "id:secret" format';
   }
+  // id is a 24-char hex Ghost ObjectId; secret is hex of any length.
+  // Catch typos / paste errors at setup time instead of at JWT signing.
+  if (!/^[a-f0-9]{24}$/.test(parts[0])) {
+    return 'ID must be a 24-character hex string';
+  }
   if (!/^[a-f0-9]+$/.test(parts[1])) {
     return 'Secret must be hex-encoded';
   }


### PR DESCRIPTION
## Summary

사용자가 `v1.0.x` / `v1.1.x`를 받은 뒤 자동 업데이트 경로가 없어 stale에 머무는 문제 해소. **git clone + 절대경로 등록** 흐름을 **`npx -y @uppinote/ghost-mcp@latest` + scoped npm package**로 전환하여 사용자가 한 번만 등록하면 editor 재시작마다 npx 캐시 정책(~24h)에 따라 자동으로 최신을 가져갑니다.

이전 PR #25를 squash 정리한 깨끗한 단일 commit. 그 PR에서 시도/롤백한 Claude Code plugin 작업은 제외됨 (별도 후속).

## What's new for users

**Before (v1.1.x)**:
```bash
git clone https://github.com/uppinote20/ghost-mcp.git
cd ghost-mcp && npm install && npm run build && npm run setup
```
Updates: 수동 `git pull && npm install && npm run build` + 에디터 재시작.

**After (v1.2.0+)**:
```bash
npx -y @uppinote/ghost-mcp@latest setup
```
Updates: 자동 (npx ~24h 캐시 후 latest fetch).

## Changes

### Package re-architecture
- `name`: `ghost-mcp` → **`@uppinote/ghost-mcp`** (scoped — unscoped는 다른 사용자가 publish 중)
- `bin`: `{ "ghost-mcp": "./dist/cli.js" }`
- **`src/cli.ts`**: `process.argv[2]`에 따라 setup wizard / stdio MCP server 분기. unknown subcommand는 명시적 stderr + exit 1 (typo 시 silent server 시작 방지)
- **`src/setup.ts`**: `scripts/setup.mjs`를 TypeScript로 이식. star prompt(PR #18) 로직 그대로. `os.homedir()` 사용으로 Docker/CI HOME 미설정 환경에서도 정확
- `src/index.ts` 유지 (backward compat — 기존 `node /path/dist/index.js` 등록자도 그대로 동작)
- `@clack/prompts` → dependencies로 이동

### Build/release automation
- `prepublishOnly`: build + test 자동 검증 — 깨진 dist publish 방지
- `.github/workflows/release.yml`: tag push 시 `npm ci → build → test → npm publish --provenance → draft release publish` 자동. **`--provenance`** 추가로 npm registry에 supply chain attestation 자동 등록 (id-token:write 권한 활용). multiple draft 방어 가드 추가 (silent wrong-notes 회피)
- `.github/workflows/claude-code-review.yml`: `allowed_bots: 'claude'` 추가 — bot push에도 review 가능

### Metadata
- `LICENSE` (MIT) — npm registry 표시용
- `files` / `publishConfig.access:public` / `repository` / `homepage` / `bugs` / `keywords`
- `dist/**/*.d.ts` 제외 (CLI-only이라 불필요)

### Documentation
- README Quick Start: `npx -y @uppinote/ghost-mcp@latest setup` 한 줄
- "Updating" / "Migrating from v1.0.x/v1.1.x" / "Development (contributors)" 섹션
- CLAUDE.md "구조" + "배포" 섹션 갱신

## Verification

- [x] `npm run build` — `dist/cli.js` shebang + executable
- [x] `npm test` — **121/121 통과**
- [x] `npm publish --dry-run` 성공 — tarball **20.2KB / 18 files** (.d.ts 제거 후 절감)
- [x] `node dist/cli.js`가 stdio server 모드로 시작 (env 검증 통과까지)
- [x] `node dist/cli.js setup` interactive wizard 진입
- [x] `node dist/cli.js bogus` → "Unknown subcommand" + exit 1
- [x] NPM_TOKEN secret이 repo에 등록됨 (이전 PR 작업)

## Migration

기존 v1.0.x/v1.1.x 사용자: README의 Migrating 섹션 안내 — `npx -y @uppinote/ghost-mcp@latest setup` 다시 돌리고 wizard의 "Overwrite?"에 yes. backward compat이라 그대로 둬도 깨지지 않지만 자동 업데이트는 안 됨.

## Test plan

- [x] Build/test passes locally
- [x] `npm publish --dry-run` accepts package contents
- [ ] Tag push triggers npm publish — 실제 v1.2.0 tag push 시 검증
- [ ] `npx -y @uppinote/ghost-mcp@latest setup` 실 사용자 시나리오 — publish 후 별도 머신에서 검증