### PR TITLE
feat: multi-client MCP setup wizard (Claude Code, Codex, Gemini)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ dist/
 *.js.map
 *.d.ts.map
 
-# Maintainer-private engineering handbook (kept in ~/.private-docs).
-# The @handbook markers in source remain public; only the handbook body is private.
-docs/ENGINEERING_HANDBOOK.md
+# Maintainer-local docs working dir: engineering handbook symlink (in
+# ~/.private-docs) + superpowers planning artifacts (plans/, specs/). The
+# @handbook markers in source stay public; only the docs/ bodies are local.
+docs/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,7 @@ npm (package-lock.json)
 | 찾는 것 | HANDBOOK 섹션 |
 |---------|---------------|
 | 모듈 의존 방향 | 1.2 |
-| MCP 부트스트랩 / Server Instructions / Setup wizard | 2 |
+| MCP 부트스트랩 / Server Instructions / Setup wizard / Multi-client adapter system | 2 |
 | JWT 토큰 / 에러 정규화 / Lazy-include | 3 |
 | Post/Page 타입 분리 | 4 |
 | Zod schema + 표 출력 / Optimistic locking / Empty-input guard | 5 |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,12 @@ npm test
 
 - `src/cli.ts` - CLI entrypoint (args에 따라 `setup` | server 분기, npm bin)
 - `src/index.ts` - legacy server entry (v1.0.x/1.1.x 사용자 backward compat)
-- `src/setup.ts` - interactive setup wizard (Ghost URL/key 입력 → editor 등록 → npx 형태)
+- `src/setup.ts` - interactive setup wizard (discover → classify → multi-select → apply via each CLI's `mcp add`)
+- `src/setup/types.ts` - McpClient interface + GhostEnv + RegisteredEntry + ClientState 공유 타입
+- `src/setup/process.ts` - spawnSync 얇은 wrapper (vi.spyOn 테스트 DI point)
+- `src/setup/dispatch.ts` - detect / read / write / remove + SERVER_NAME/CANONICAL_CMD/CANONICAL_ARGS 상수
+- `src/setup/classify.ts` - 상태 분류 (in-sync/stale/missing) + canonical 값 resolution
+- `src/setup/clients/` - 클라이언트별 adapter (claude-code, codex, gemini) — first-party `mcp add` CLI 사용
 - `src/server.ts` - MCP server 인스턴스화 + 도구 등록
 - `src/config.ts` - 환경변수 로딩 + HTTPS/API 키 검증
 - `src/validation.ts` - 입력값 검증 (ghostId, safeSlug, path traversal 방지)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,10 +16,10 @@ npm test
 - `src/index.ts` - legacy server entry (v1.0.x/1.1.x 사용자 backward compat)
 - `src/setup.ts` - interactive setup wizard (discover → classify → multi-select → apply via each CLI's `mcp add`)
 - `src/setup/types.ts` - McpClient interface + GhostEnv + RegisteredEntry + ClientState 공유 타입
-- `src/setup/process.ts` - spawnSync 얇은 wrapper (vi.spyOn 테스트 DI point)
+- `src/setup/process.ts` - async spawn wrapper (스캔 spinner 애니메이션용; vi.spyOn 테스트 DI point)
 - `src/setup/dispatch.ts` - detect / read / write / remove + SERVER_NAME/CANONICAL_CMD/CANONICAL_ARGS 상수
 - `src/setup/classify.ts` - 상태 분류 (in-sync/stale/missing) + canonical 값 resolution
-- `src/setup/clients/` - 클라이언트별 adapter (claude-code, codex, gemini) — first-party `mcp add` CLI 사용
+- `src/setup/clients/` - 클라이언트별 adapter (claude-code, codex, gemini) + `json-config.ts` 공용 reader. 쓰기는 `mcp add` CLI, 읽기는 codex만 CLI이고 claude/gemini는 설정 파일 직접
 - `src/server.ts` - MCP server 인스턴스화 + 도구 등록
 - `src/config.ts` - 환경변수 로딩 + HTTPS/API 키 검증
 - `src/validation.ts` - 입력값 검증 (ghostId, safeSlug, path traversal 방지)

--- a/README.md
+++ b/README.md
@@ -19,10 +19,15 @@ Create, edit, publish, and sync blog posts directly from Claude Code, Cursor, or
 npx -y @uppinote/ghost-mcp@latest setup
 ```
 
-The setup wizard registers the server in your editor and prompts for the Ghost URL + Admin API Key:
+The wizard auto-detects supported CLIs (Claude Code, Codex CLI, Gemini CLI), shows the current registration state of each, prompts for the Ghost URL + Admin API Key, and registers via each CLI's own `mcp add` command:
 
 ```
 ┌  ghost-mcp setup
+│
+◇  MCP clients
+│    ⚠  Claude Code   stale — args are [...dev-clone...]
+│    ○  Codex CLI     not registered
+│    ○  Gemini CLI    not registered
 │
 ◆  Ghost blog URL
 │  https://your-blog.com
@@ -30,15 +35,17 @@ The setup wizard registers the server in your editor and prompts for the Ghost U
 ◆  Admin API Key (Ghost → Settings → Integrations)
 │  ************************************
 │
-◆  Register in
-│  ● Claude Code
-│  ○ Cursor
-│  ○ Print config (manual setup)
+◆  Apply to which clients?
+│  ◼ Claude Code (fix stale)
+│  ◼ Codex CLI (new install)
+│  ◼ Gemini CLI (new install)
 │
-└  Restart your editor to activate.
+└  Restart: Claude Code, Codex CLI, Gemini CLI
 ```
 
-After setup, your editor is registered with `npx -y @uppinote/ghost-mcp@latest`, so you'll automatically pick up new releases on the next start (npm cache TTL ~24h).
+State symbols: `✓` in-sync · `⚠` stale (will fix) · `○` not registered (will install). One command covers install, update, and drift-fix across every detected CLI — re-run anytime to verify or after rotating your API key.
+
+Each CLI is registered via its first-party command (`claude mcp add -s user`, `codex mcp add`, `gemini mcp add -s user`) with `npx -y @uppinote/ghost-mcp@latest`, so you automatically pick up new releases on the next CLI restart (npm cache TTL ~24h).
 
 > The setup wizard shows a one-time GitHub star prompt. Pass `--yes` to skip the prompt, or `--star` to star without asking.
 
@@ -48,7 +55,31 @@ Because the editor is registered with `npx -y ...@latest`, restarts pick up new 
 
 ## Manual Setup
 
-If you prefer to configure manually, add to your MCP settings:
+The wizard is the recommended path for Claude Code / Codex / Gemini because each CLI owns its own config format. If you need to configure manually:
+
+**Claude Code, Codex CLI, Gemini CLI** — use their first-party commands directly:
+
+```bash
+# Claude Code
+claude mcp add -s user ghost-blog \
+  -e GHOST_URL=https://your-blog.com \
+  -e GHOST_ADMIN_API_KEY=your_id:your_hex_secret \
+  -- npx -y @uppinote/ghost-mcp@latest
+
+# Codex CLI
+codex mcp add \
+  --env GHOST_URL=https://your-blog.com \
+  --env GHOST_ADMIN_API_KEY=your_id:your_hex_secret \
+  ghost-blog -- npx -y @uppinote/ghost-mcp@latest
+
+# Gemini CLI
+gemini mcp add -s user ghost-blog \
+  -e GHOST_URL=https://your-blog.com \
+  -e GHOST_ADMIN_API_KEY=your_id:your_hex_secret \
+  npx -y @uppinote/ghost-mcp@latest
+```
+
+**Other MCP-compatible clients** (Cursor, Claude Desktop, Windsurf, etc.) — add this entry to your client's MCP settings file:
 
 ```json
 {
@@ -65,17 +96,18 @@ If you prefer to configure manually, add to your MCP settings:
 }
 ```
 
-| Editor | Settings file |
+| Client | Settings file |
 |--------|--------------|
-| Claude Code | `~/.claude/settings.json` |
 | Cursor | `~/.cursor/mcp.json` |
+| Claude Desktop | `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) |
+| Windsurf | `~/.codeium/windsurf/mcp_config.json` |
 
 ## Migrating from v1.0.x / v1.1.x
 
 Earlier versions registered the server with `node /path/to/dist/index.js`, which doesn't auto-update. To switch to the npx flow:
 
-1. Run `npx -y @uppinote/ghost-mcp@latest setup` and choose "overwrite" when it detects the existing entry.
-2. Restart your editor.
+1. Run `npx -y @uppinote/ghost-mcp@latest setup`. The wizard detects the old dev-clone registration as `⚠ stale` and offers to replace it with `npx -y @uppinote/ghost-mcp@latest`. Confirm in the multiselect prompt.
+2. Restart your CLI.
 3. (Optional) Delete the old `git clone` directory.
 
 ## Development (contributors)

--- a/src/setup.test.ts
+++ b/src/setup.test.ts
@@ -107,4 +107,31 @@ describe('setup wizard — discover → apply', () => {
     expect(addIdx).toBeGreaterThanOrEqual(0);
     expect(removeIdx).toBeLessThan(addIdx); // remove happens before add
   });
+
+  it('reports failure and omits the failed client from the restart list', async () => {
+    const prompts = await import('@clack/prompts');
+    (prompts.multiselect as ReturnType<typeof vi.fn>).mockResolvedValueOnce(['claude-code']);
+
+    stubClaudeConfig(null); // missing → wizard attempts write
+    // claude installed, but `mcp add` fails (e.g. permission denied)
+    vi.spyOn(proc, 'run').mockImplementation(async (cli: string, args: string[]) => {
+      if (args[0] === '--version') {
+        return cli === 'claude'
+          ? { status: 0, stdout: '1', stderr: '' }
+          : { status: 127, stdout: '', stderr: '' };
+      }
+      if (args[0] === 'mcp' && args[1] === 'add') {
+        return { status: 1, stdout: '', stderr: 'permission denied' };
+      }
+      return { status: 0, stdout: '', stderr: '' };
+    });
+
+    const { runSetup } = await import('./setup.js');
+    await expect(runSetup()).resolves.not.toThrow();
+
+    const { outro } = await import('@clack/prompts');
+    const outroArg = (outro as ReturnType<typeof vi.fn>).mock.calls.at(-1)?.[0] ?? '';
+    // failed client must not be told to restart
+    expect(outroArg).not.toMatch(/Claude Code/);
+  });
 });

--- a/src/setup.test.ts
+++ b/src/setup.test.ts
@@ -1,5 +1,6 @@
 /** @covers src/setup.ts */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import fs from 'node:fs';
 import * as proc from './setup/process.js';
 
 // Mock @clack/prompts to feed deterministic answers
@@ -11,7 +12,7 @@ vi.mock('@clack/prompts', async () => {
     outro: vi.fn(),
     note: vi.fn(),
     log: { info: vi.fn(), success: vi.fn(), error: vi.fn() },
-    spinner: () => ({ start: vi.fn(), stop: vi.fn() }),
+    spinner: () => ({ start: vi.fn(), stop: vi.fn(), message: vi.fn() }),
     text: vi.fn().mockResolvedValue('https://blog.example.com'),
     password: vi.fn().mockResolvedValue('id-1234567890abcdef:secret-key-32-chars-here-aaa-bbb'),
     multiselect: vi.fn(),
@@ -21,11 +22,34 @@ vi.mock('@clack/prompts', async () => {
   };
 });
 
-beforeEach(() => { vi.restoreAllMocks(); });
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+// claude's readEntry reads ~/.claude.json via fs.readFileSync — stub it so the
+// wizard sees a specific user-scope registration (or none).
+function stubClaudeConfig(entry: { command: string; args: string[] } | null): void {
+  vi.spyOn(fs, 'readFileSync').mockReturnValue(
+    JSON.stringify(entry ? { mcpServers: { 'ghost-blog': entry } } : { mcpServers: {} })
+  );
+}
+
+// Only Claude Code is "installed"; codex/gemini --version fail. Non-version
+// calls (mcp add/remove) succeed.
+function onlyClaudeInstalled() {
+  return vi.spyOn(proc, 'run').mockImplementation(async (cli: string, args: string[]) => {
+    if (args[0] === '--version') {
+      return cli === 'claude'
+        ? { status: 0, stdout: '1', stderr: '' }
+        : { status: 127, stdout: '', stderr: '' };
+    }
+    return { status: 0, stdout: '', stderr: '' };
+  });
+}
 
 describe('setup wizard — discover → apply', () => {
   it('exits cleanly when no MCP CLI is detected', async () => {
-    vi.spyOn(proc, 'run').mockReturnValue({ status: 127, stdout: '', stderr: 'not found' });
+    vi.spyOn(proc, 'run').mockResolvedValue({ status: 127, stdout: '', stderr: 'not found' });
     const { runSetup } = await import('./setup.js');
     await expect(runSetup()).resolves.not.toThrow();
   });
@@ -34,12 +58,8 @@ describe('setup wizard — discover → apply', () => {
     const prompts = await import('@clack/prompts');
     (prompts.multiselect as ReturnType<typeof vi.fn>).mockResolvedValueOnce(['claude-code']);
 
-    const spy = vi.spyOn(proc, 'run').mockImplementation((cli: string, args: string[]) => {
-      if (args[0] === '--version') return cli === 'claude' ? { status: 0, stdout: '1', stderr: '' } : { status: 127, stdout: '', stderr: '' };
-      if (args[0] === 'mcp' && args[1] === 'list') return { status: 0, stdout: '', stderr: '' };  // empty → parseGet returns null → classify missing
-      if (args[0] === 'mcp' && args[1] === 'add') return { status: 0, stdout: '', stderr: '' };
-      return { status: 0, stdout: '', stderr: '' };
-    });
+    stubClaudeConfig(null); // ~/.claude.json has no ghost-blog → missing
+    const spy = onlyClaudeInstalled();
 
     const { runSetup } = await import('./setup.js');
     await runSetup();
@@ -54,20 +74,33 @@ describe('setup wizard — discover → apply', () => {
     const prompts = await import('@clack/prompts');
     (prompts.multiselect as ReturnType<typeof vi.fn>).mockResolvedValueOnce(['claude-code']);
 
-    // In-sync list output: command+args match canonical npx invocation
-    const inSyncList = `ghost-blog: npx -y @uppinote/ghost-mcp@latest - ✓ Connected\n`;
-
-    const spy = vi.spyOn(proc, 'run').mockImplementation((cli: string, args: string[]) => {
-      if (args[0] === '--version') return cli === 'claude' ? { status: 0, stdout: '1', stderr: '' } : { status: 127, stdout: '', stderr: '' };
-      if (args[0] === 'mcp' && args[1] === 'list') return { status: 0, stdout: inSyncList, stderr: '' };
-      if (args[0] === 'mcp' && args[1] === 'add') return { status: 0, stdout: '', stderr: '' };
-      return { status: 0, stdout: '', stderr: '' };
-    });
+    // user-scope entry already matches the canonical npx invocation → in-sync
+    stubClaudeConfig({ command: 'npx', args: ['-y', '@uppinote/ghost-mcp@latest'] });
+    const spy = onlyClaudeInstalled();
 
     const { runSetup } = await import('./setup.js');
     await runSetup();
 
     const addCall = spy.mock.calls.find(([c, a]) => c === 'claude' && a[0] === 'mcp' && a[1] === 'add');
     expect(addCall).toBeUndefined();
+  });
+
+  it('removes then adds for a stale client (the node → npx migration)', async () => {
+    const prompts = await import('@clack/prompts');
+    (prompts.multiselect as ReturnType<typeof vi.fn>).mockResolvedValueOnce(['claude-code']);
+
+    // user-scope entry is an old dev-clone node command → stale vs canonical npx
+    stubClaudeConfig({ command: 'node', args: ['/path/dist/index.js'] });
+    const spy = onlyClaudeInstalled();
+
+    const { runSetup } = await import('./setup.js');
+    await runSetup();
+
+    const claudeCalls = spy.mock.calls.filter(([c]) => c === 'claude').map(([, a]) => a);
+    const removeIdx = claudeCalls.findIndex((a) => a[0] === 'mcp' && a[1] === 'remove');
+    const addIdx = claudeCalls.findIndex((a) => a[0] === 'mcp' && a[1] === 'add');
+    expect(removeIdx).toBeGreaterThanOrEqual(0);
+    expect(addIdx).toBeGreaterThanOrEqual(0);
+    expect(removeIdx).toBeLessThan(addIdx); // remove happens before add
   });
 });

--- a/src/setup.test.ts
+++ b/src/setup.test.ts
@@ -1,0 +1,73 @@
+/** @covers src/setup.ts */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import * as proc from './setup/process.js';
+
+// Mock @clack/prompts to feed deterministic answers
+vi.mock('@clack/prompts', async () => {
+  const actual = await vi.importActual<typeof import('@clack/prompts')>('@clack/prompts');
+  return {
+    ...actual,
+    intro: vi.fn(),
+    outro: vi.fn(),
+    note: vi.fn(),
+    log: { info: vi.fn(), success: vi.fn(), error: vi.fn() },
+    spinner: () => ({ start: vi.fn(), stop: vi.fn() }),
+    text: vi.fn().mockResolvedValue('https://blog.example.com'),
+    password: vi.fn().mockResolvedValue('id-1234567890abcdef:secret-key-32-chars-here-aaa-bbb'),
+    multiselect: vi.fn(),
+    confirm: vi.fn().mockResolvedValue(false),
+    isCancel: vi.fn().mockReturnValue(false),
+    cancel: vi.fn(),
+  };
+});
+
+beforeEach(() => { vi.restoreAllMocks(); });
+
+describe('setup wizard — discover → apply', () => {
+  it('exits cleanly when no MCP CLI is detected', async () => {
+    vi.spyOn(proc, 'run').mockReturnValue({ status: 127, stdout: '', stderr: 'not found' });
+    const { runSetup } = await import('./setup.js');
+    await expect(runSetup()).resolves.not.toThrow();
+  });
+
+  it('writes to a detected client that is missing the server', async () => {
+    const prompts = await import('@clack/prompts');
+    (prompts.multiselect as ReturnType<typeof vi.fn>).mockResolvedValueOnce(['claude-code']);
+
+    const spy = vi.spyOn(proc, 'run').mockImplementation((cli: string, args: string[]) => {
+      if (args[0] === '--version') return cli === 'claude' ? { status: 0, stdout: '1', stderr: '' } : { status: 127, stdout: '', stderr: '' };
+      if (args[0] === 'mcp' && args[1] === 'list') return { status: 0, stdout: '', stderr: '' };  // empty → parseGet returns null → classify missing
+      if (args[0] === 'mcp' && args[1] === 'add') return { status: 0, stdout: '', stderr: '' };
+      return { status: 0, stdout: '', stderr: '' };
+    });
+
+    const { runSetup } = await import('./setup.js');
+    await runSetup();
+
+    const addCall = spy.mock.calls.find(([c, a]) => c === 'claude' && a[0] === 'mcp' && a[1] === 'add');
+    expect(addCall).toBeDefined();
+    expect(addCall![1]).toContain('-s');
+    expect(addCall![1]).toContain('user');
+  });
+
+  it('skips write for an in-sync client even when the user checks the box', async () => {
+    const prompts = await import('@clack/prompts');
+    (prompts.multiselect as ReturnType<typeof vi.fn>).mockResolvedValueOnce(['claude-code']);
+
+    // In-sync list output: command+args match canonical npx invocation
+    const inSyncList = `ghost-blog: npx -y @uppinote/ghost-mcp@latest - ✓ Connected\n`;
+
+    const spy = vi.spyOn(proc, 'run').mockImplementation((cli: string, args: string[]) => {
+      if (args[0] === '--version') return cli === 'claude' ? { status: 0, stdout: '1', stderr: '' } : { status: 127, stdout: '', stderr: '' };
+      if (args[0] === 'mcp' && args[1] === 'list') return { status: 0, stdout: inSyncList, stderr: '' };
+      if (args[0] === 'mcp' && args[1] === 'add') return { status: 0, stdout: '', stderr: '' };
+      return { status: 0, stdout: '', stderr: '' };
+    });
+
+    const { runSetup } = await import('./setup.js');
+    await runSetup();
+
+    const addCall = spy.mock.calls.find(([c, a]) => c === 'claude' && a[0] === 'mcp' && a[1] === 'add');
+    expect(addCall).toBeUndefined();
+  });
+});

--- a/src/setup.test.ts
+++ b/src/setup.test.ts
@@ -70,19 +70,23 @@ describe('setup wizard — discover → apply', () => {
     expect(addCall![1]).toContain('user');
   });
 
-  it('skips write for an in-sync client even when the user checks the box', async () => {
+  it('re-applies a selected in-sync client so credential changes (key rotation) take effect', async () => {
     const prompts = await import('@clack/prompts');
     (prompts.multiselect as ReturnType<typeof vi.fn>).mockResolvedValueOnce(['claude-code']);
 
-    // user-scope entry already matches the canonical npx invocation → in-sync
+    // command/args already match canonical → in-sync, but env is masked so a
+    // rotated key is invisible. Keeping it selected must still rewrite it.
     stubClaudeConfig({ command: 'npx', args: ['-y', '@uppinote/ghost-mcp@latest'] });
     const spy = onlyClaudeInstalled();
 
     const { runSetup } = await import('./setup.js');
     await runSetup();
 
-    const addCall = spy.mock.calls.find(([c, a]) => c === 'claude' && a[0] === 'mcp' && a[1] === 'add');
-    expect(addCall).toBeUndefined();
+    const claudeCalls = spy.mock.calls.filter(([c]) => c === 'claude').map(([, a]) => a);
+    const removeIdx = claudeCalls.findIndex((a) => a[0] === 'mcp' && a[1] === 'remove');
+    const addIdx = claudeCalls.findIndex((a) => a[0] === 'mcp' && a[1] === 'add');
+    expect(addIdx).toBeGreaterThanOrEqual(0); // re-added → credentials refreshed
+    expect(removeIdx).toBeLessThan(addIdx); // replace: remove before add
   });
 
   it('removes then adds for a stale client (the node → npx migration)', async () => {

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -57,34 +57,24 @@ function scan(): ScanRow[] {
 
 function reclassify(rows: ScanRow[], canonical: GhostEnv): ScanRow[] {
   return rows.map(({ client, state }) => {
-    if (
-      state.kind === 'missing' ||
-      state.kind === 'absent' ||
-      state.kind === 'unparseable'
-    ) {
-      return { client, state };
-    }
+    if (state.kind === 'missing') return { client, state };
     return { client, state: classify(canonical, state.entry) };
   });
 }
 
 function symbol(state: ClientState): string {
   switch (state.kind) {
-    case 'in-sync':     return '✓';
-    case 'stale':       return '⚠';
-    case 'missing':     return '○';
-    case 'unparseable': return '?';
-    case 'absent':      return '—';
+    case 'in-sync': return '✓';
+    case 'stale':   return '⚠';
+    case 'missing': return '○';
   }
 }
 
 function summary(state: ClientState): string {
   switch (state.kind) {
-    case 'in-sync':     return 'in-sync';
-    case 'stale':       return `stale — ${state.reasons[0]}`;
-    case 'missing':     return 'not registered';
-    case 'unparseable': return 'config not parseable';
-    case 'absent':      return 'CLI not installed';
+    case 'in-sync': return 'in-sync';
+    case 'stale':   return `stale — ${state.reasons[0]}`;
+    case 'missing': return 'not registered';
   }
 }
 
@@ -277,7 +267,6 @@ export async function runSetup(): Promise<void> {
 
   // 6. MULTISELECT — which clients to update
   const options = finalRows
-    .filter((r) => r.state.kind !== 'unparseable')
     .map((r) => ({
       value: r.client.id,
       label: `${r.client.label} (${summary(r.state)})`,
@@ -293,9 +282,7 @@ export async function runSetup(): Promise<void> {
     })
   );
 
-  const selectedIds = new Set(
-    Array.isArray(selected) ? selected : []
-  );
+  const selectedIds = new Set(selected);
 
   // 7. APPLY — skip in-sync entries per spec §8.2
   let applied = 0;

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -15,9 +15,9 @@
  * @handbook 2.4-setup-wizard
  * @tested src/setup.test.ts
  */
-import fs from 'fs';
-import os from 'os';
-import path from 'path';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import {
   intro,
   outro,
@@ -170,7 +170,7 @@ async function offerStar(flags: StarFlags): Promise<void> {
   });
 
   if (isCancel(yes)) return;
-  if (yes) tryStar();
+  if (yes) await tryStar();
 }
 
 // ── Main ─────────────────────────────────────────
@@ -335,8 +335,16 @@ export async function runSetup(): Promise<void> {
   await offerStar({ yes: flagYes, star: flagStar, forceStarPrompt: flagForceStarPrompt });
 
   // 10. Outro with restart list
+  // Exclude clients whose write() failed — they were not actually updated, so
+  // telling the user to restart them would be misleading.
+  const failedIds = new Set(failures.map((f) => f.client.id));
   const restartClients = finalRows
-    .filter((r) => selectedIds.has(r.client.id) && r.state.kind !== 'in-sync')
+    .filter(
+      (r) =>
+        selectedIds.has(r.client.id) &&
+        r.state.kind !== 'in-sync' &&
+        !failedIds.has(r.client.id)
+    )
     .map((r) => r.client.label);
 
   if (restartClients.length > 0) {

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -13,6 +13,7 @@
  *   --force-star-prompt re-ask even if already prompted
  *
  * @handbook 2.4-setup-wizard
+ * @tested src/setup.test.ts
  */
 import fs from 'fs';
 import os from 'os';

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -332,16 +332,12 @@ export async function runSetup(): Promise<void> {
   await offerStar({ yes: flagYes, star: flagStar, forceStarPrompt: flagForceStarPrompt });
 
   // 10. Outro with restart list
-  // Exclude clients whose write() failed — they were not actually updated, so
-  // telling the user to restart them would be misleading.
+  // Every selected client that was successfully (re)written needs a restart —
+  // including in-sync ones, which are now re-applied for credential rotation.
+  // Exclude only clients whose write() failed (not actually updated).
   const failedIds = new Set(failures.map((f) => f.client.id));
   const restartClients = finalRows
-    .filter(
-      (r) =>
-        selectedIds.has(r.client.id) &&
-        r.state.kind !== 'in-sync' &&
-        !failedIds.has(r.client.id)
-    )
+    .filter((r) => selectedIds.has(r.client.id) && !failedIds.has(r.client.id))
     .map((r) => r.client.label);
 
   if (restartClients.length > 0) {

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -1,7 +1,7 @@
 /**
  * Interactive setup for ghost-mcp.
- * Registers the MCP server in your editor's config using `npx -y` invocation
- * so the editor always picks up the latest published version.
+ * Registers the MCP server across all detected MCP-capable CLIs using first-party
+ * `mcp add` commands — no direct JSON-file writes.
  *
  * Invoked via:
  *   npx -y @uppinote/ghost-mcp@latest setup
@@ -23,56 +23,81 @@ import {
   outro,
   text,
   password,
-  select,
+  multiselect,
   confirm,
   note,
   cancel,
   isCancel,
-  spinner,
   log,
 } from '@clack/prompts';
 import { checkGhostUrl, checkGhostKey } from './validation.js';
+import { ALL_CLIENTS } from './setup/clients/index.js';
+import { detect, read, write, SERVER_NAME } from './setup/dispatch.js';
+import { classify, resolveCanonical } from './setup/classify.js';
+import { McpClient, ClientState, GhostEnv } from './setup/types.js';
 
 const REPO = 'uppinote20/ghost-mcp';
 const REPO_URL = `https://github.com/${REPO}`;
-const NPM_PACKAGE = '@uppinote/ghost-mcp';
 
-// ── Editor config paths ─────────────────────────
+// ── Helpers ──────────────────────────────────────
 
 const HOME = os.homedir();
 const STAR_MARKER = path.join(HOME, '.config', 'ghost-mcp', '.star-prompted');
 
-const EDITORS: Record<
-  string,
-  { label: string; path: string | null; key: string }
-> = {
-  'claude-code': {
-    label: 'Claude Code',
-    path: path.join(HOME, '.claude', 'settings.json'),
-    key: 'mcpServers',
-  },
-  cursor: {
-    label: 'Cursor',
-    path: path.join(HOME, '.cursor', 'mcp.json'),
-    key: 'mcpServers',
-  },
-  print: {
-    label: 'Print config (manual setup)',
-    path: null,
-    key: 'mcpServers',
-  },
-};
+type ScanRow = { client: McpClient; state: ClientState };
 
-// ── Helpers ──────────────────────────────────────
+function scan(): ScanRow[] {
+  const detected = ALL_CLIENTS.filter(detect);
+  const stub: GhostEnv = { GHOST_URL: '', GHOST_ADMIN_API_KEY: '' };
+  return detected.map((client) => ({
+    client,
+    state: classify(stub, read(client)),
+  }));
+}
+
+function reclassify(rows: ScanRow[], canonical: GhostEnv): ScanRow[] {
+  return rows.map(({ client, state }) => {
+    if (
+      state.kind === 'missing' ||
+      state.kind === 'absent' ||
+      state.kind === 'unparseable'
+    ) {
+      return { client, state };
+    }
+    return { client, state: classify(canonical, state.entry) };
+  });
+}
+
+function symbol(state: ClientState): string {
+  switch (state.kind) {
+    case 'in-sync':     return '✓';
+    case 'stale':       return '⚠';
+    case 'missing':     return '○';
+    case 'unparseable': return '?';
+    case 'absent':      return '—';
+  }
+}
+
+function summary(state: ClientState): string {
+  switch (state.kind) {
+    case 'in-sync':     return 'in-sync';
+    case 'stale':       return `stale — ${state.reasons[0]}`;
+    case 'missing':     return 'not registered';
+    case 'unparseable': return 'config not parseable';
+    case 'absent':      return 'CLI not installed';
+  }
+}
+
+function renderRows(rows: ScanRow[]): void {
+  const lines = rows.map(({ client, state }) =>
+    `  ${symbol(state)}  ${client.label.padEnd(14)}  ${summary(state)}`
+  );
+  note(lines.join('\n'), 'MCP clients');
+}
 
 function bail(msg: string): never {
   cancel(msg);
   process.exit(0);
-}
-
-function bailError(msg: string): never {
-  cancel(msg);
-  process.exit(1);
 }
 
 function check<T>(value: T | symbol): T {
@@ -170,103 +195,143 @@ export async function runSetup(): Promise<void> {
   const flagStar = args.has('--star');
   const flagForceStarPrompt = args.has('--force-star-prompt');
 
+  // 1. Intro
   intro('ghost-mcp setup');
 
-  // 1. Ghost URL
+  // 2. SCAN — detect all installed MCP CLIs and their current registration state
+  const rows = scan();
+
+  if (rows.length === 0) {
+    note(
+      'No supported MCP CLI detected (Claude Code, Codex CLI, Gemini CLI).\nInstall one of them first.',
+      'No clients found'
+    );
+    outro('No changes made.');
+    return;
+  }
+
+  renderRows(rows);
+
+  // 3. RESOLVE CANONICAL (initial) — from any in-sync entries
+  const inSyncEnvs = rows
+    .filter((r) => r.state.kind === 'in-sync')
+    .map((r) => {
+      const s = r.state;
+      if (s.kind !== 'in-sync') return null;
+      return s.entry.env as GhostEnv;
+    })
+    .filter((e): e is GhostEnv => e !== null);
+
+  const initialCanon = resolveCanonical(inSyncEnvs);
+
+  if (initialCanon === 'conflict') {
+    note(
+      'In-sync clients have disagreeing values — you will choose the canonical values below.',
+      'Conflict detected'
+    );
+  }
+
+  const defaultUrl =
+    initialCanon && initialCanon !== 'conflict' ? initialCanon.GHOST_URL : '';
+  const defaultKey =
+    initialCanon && initialCanon !== 'conflict'
+      ? initialCanon.GHOST_ADMIN_API_KEY
+      : '';
+
+  // 4. PROMPT URL + KEY
   const ghostUrl = check(
     await text({
       message: 'Ghost blog URL',
       placeholder: 'https://your-blog.com',
+      initialValue: defaultUrl,
       validate: checkGhostUrl,
     })
   );
 
-  // 2. Admin API Key
   const apiKey = check(
     await password({
       message: 'Admin API Key (Ghost → Settings → Integrations)',
       mask: '*',
-      validate: checkGhostKey,
+      validate: (v) => {
+        // Allow pressing Enter to keep the canonical key (pre-filled is masked)
+        if (v === defaultKey) return undefined;
+        return checkGhostKey(v);
+      },
     })
   );
 
-  // 3. Editor selection
-  const editor = check(
-    await select({
-      message: 'Register in',
-      options: [
-        { value: 'claude-code', label: 'Claude Code', hint: '~/.claude/settings.json' },
-        { value: 'cursor', label: 'Cursor', hint: '~/.cursor/mcp.json' },
-        { value: 'print', label: 'Print config (manual setup)' },
-      ] as const,
-    })
-  );
-
-  // 4. Build MCP config — uses `npx -y` so the editor always pulls the latest
-  //    published version on next start (npm cache TTL is ~24h). Normalise URL
-  //    once so the success note and the saved config show the same value.
-  const normalisedUrl = ghostUrl.replace(/\/$/, '');
-  const serverConfig = {
-    command: 'npx',
-    args: ['-y', `${NPM_PACKAGE}@latest`],
-    env: {
-      GHOST_URL: normalisedUrl,
-      GHOST_ADMIN_API_KEY: apiKey,
-    },
+  const canonical: GhostEnv = {
+    GHOST_URL: ghostUrl.replace(/\/$/, ''),
+    GHOST_ADMIN_API_KEY: apiKey || defaultKey,
   };
 
-  // 5. Print or write
-  if (editor === 'print') {
-    note(
-      JSON.stringify({ mcpServers: { 'ghost-blog': serverConfig } }, null, 2),
-      'Add this to your MCP config'
-    );
-    await offerStar({ yes: flagYes, star: flagStar, forceStarPrompt: flagForceStarPrompt });
-    outro('Copy the config above to your editor settings.');
-    return;
-  }
+  // 5. RECLASSIFY against final canonical
+  const finalRows = reclassify(rows, canonical);
 
-  const { path: settingsPath, key } = EDITORS[editor];
-  if (!settingsPath) bailError('Internal: editor has no settings path');
+  // 6. MULTISELECT — which clients to update
+  const options = finalRows
+    .filter((r) => r.state.kind !== 'unparseable')
+    .map((r) => ({
+      value: r.client.id,
+      label: `${r.client.label} (${summary(r.state)})`,
+      hint: r.state.kind === 'in-sync' ? 'skip — already in-sync' : undefined,
+    }));
 
-  // Read existing settings
-  let settings: Record<string, Record<string, unknown>> = {};
-  if (fs.existsSync(settingsPath)) {
+  const selected = check(
+    await multiselect({
+      message: 'Apply to',
+      options,
+      initialValues: options.map((o) => o.value),
+      required: false,
+    })
+  );
+
+  const selectedIds = new Set(
+    Array.isArray(selected) ? selected : []
+  );
+
+  // 7. APPLY — skip in-sync entries per spec §8.2
+  let applied = 0;
+  let skipped = 0;
+  const failures: Array<{ client: McpClient; error: unknown }> = [];
+
+  for (const { client, state } of finalRows) {
+    if (!selectedIds.has(client.id)) continue;
+    if (state.kind === 'in-sync') {
+      skipped++;
+      continue;
+    }
     try {
-      settings = JSON.parse(fs.readFileSync(settingsPath, 'utf-8'));
-    } catch {
-      log.error(`Failed to parse ${settingsPath}`);
-      bailError('Fix the file manually and retry');
+      write(client, canonical, SERVER_NAME);
+      applied++;
+    } catch (e) {
+      failures.push({ client, error: e });
     }
   }
 
-  if (!settings[key]) settings[key] = {};
-
-  if (settings[key]['ghost-blog']) {
-    const overwrite = check(
-      await confirm({
-        message: 'ghost-blog is already configured. Overwrite?',
-        initialValue: false,
-      })
-    );
-    if (!overwrite) bail('Keeping existing config');
+  // 8. REPORT
+  const reportLines: string[] = [];
+  if (applied > 0) reportLines.push(`✓  Applied to ${applied} client(s)`);
+  if (skipped > 0) reportLines.push(`○  Skipped ${skipped} already in-sync`);
+  if (failures.length > 0) {
+    reportLines.push(`✗  Failed: ${failures.map((f) => f.client.label).join(', ')}`);
+    for (const { client, error } of failures) {
+      log.error(`${client.label}: ${error instanceof Error ? error.message : String(error)}`);
+    }
   }
+  if (reportLines.length > 0) note(reportLines.join('\n'), 'Result');
 
-  const s = spinner();
-  s.start('Writing config');
-
-  settings[key]['ghost-blog'] = serverConfig;
-  fs.mkdirSync(path.dirname(settingsPath), { recursive: true });
-  fs.writeFileSync(settingsPath, JSON.stringify(settings, null, 2) + '\n');
-
-  s.stop('Config saved');
-
-  note(
-    `Package: ${NPM_PACKAGE}@latest (auto-updated by npx)\nGhost:   ${normalisedUrl}`,
-    'ghost-blog registered'
-  );
-
+  // 9. Star prompt
   await offerStar({ yes: flagYes, star: flagStar, forceStarPrompt: flagForceStarPrompt });
 
-  outro(`Restart ${EDITORS[editor].label} to activate the MCP server.`);
+  // 10. Outro with restart list
+  const restartClients = finalRows
+    .filter((r) => selectedIds.has(r.client.id) && r.state.kind !== 'in-sync')
+    .map((r) => r.client.label);
+
+  if (restartClients.length > 0) {
+    outro(`Restart ${restartClients.join(', ')} to activate the MCP server.`);
+  } else {
+    outro('Done.');
+  }
 }

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -298,21 +298,19 @@ export async function runSetup(): Promise<void> {
 
   const selectedIds = new Set(selected);
 
-  // 7. APPLY — skip in-sync entries per spec §8.2
+  // 7. APPLY — (re)write every selected client. env is masked (adapters return
+  // env: {}), so we cannot tell whether the entered credentials differ from
+  // what's stored; skipping "in-sync" clients would silently drop credential
+  // updates such as API-key rotation. Existing entries (in-sync or stale) pass
+  // replace so `mcp add` doesn't fail on "already exists".
   let applied = 0;
-  let skipped = 0;
   const failures: Array<{ client: McpClient; error: unknown }> = [];
 
   for (const { client, state } of finalRows) {
     if (!selectedIds.has(client.id)) continue;
-    if (state.kind === 'in-sync') {
-      skipped++;
-      continue;
-    }
+    const exists = state.kind === 'in-sync' || state.kind === 'stale';
     try {
-      // Stale entries pass replace=true so write removes the differing entry
-      // before re-adding (most CLIs' `mcp add` refuses to overwrite).
-      await write(client, canonical, SERVER_NAME, { replace: state.kind === 'stale' });
+      await write(client, canonical, SERVER_NAME, { replace: exists });
       applied++;
     } catch (e) {
       failures.push({ client, error: e });
@@ -322,7 +320,6 @@ export async function runSetup(): Promise<void> {
   // 8. REPORT
   const reportLines: string[] = [];
   if (applied > 0) reportLines.push(`✓  Applied to ${applied} client(s)`);
-  if (skipped > 0) reportLines.push(`○  Skipped ${skipped} already in-sync`);
   if (failures.length > 0) {
     reportLines.push(`✗  Failed: ${failures.map((f) => f.client.label).join(', ')}`);
     for (const { client, error } of failures) {

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -218,7 +218,12 @@ export async function runSetup(): Promise<void> {
     .map((r) => {
       const s = r.state;
       if (s.kind !== 'in-sync') return null;
-      return s.entry.env as GhostEnv;
+      // Adapters that mask env return env={} — coerce missing fields to ''
+      // so resolveCanonical's strict equality does not key on undefined.
+      return {
+        GHOST_URL: s.entry.env.GHOST_URL ?? '',
+        GHOST_ADMIN_API_KEY: s.entry.env.GHOST_ADMIN_API_KEY ?? '',
+      };
     })
     .filter((e): e is GhostEnv => e !== null);
 
@@ -253,8 +258,10 @@ export async function runSetup(): Promise<void> {
       message: 'Admin API Key (Ghost → Settings → Integrations)',
       mask: '*',
       validate: (v) => {
-        // Allow pressing Enter to keep the canonical key (pre-filled is masked)
-        if (v === defaultKey) return undefined;
+        // Allow pressing Enter to keep the canonical key (only when one exists).
+        // Without this `defaultKey &&` guard, empty input would silently match
+        // an empty default — first-time setup users could submit a blank key.
+        if (defaultKey && v === defaultKey) return undefined;
         return checkGhostKey(v);
       },
     })

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -18,7 +18,6 @@
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
-import { spawnSync } from 'child_process';
 import {
   intro,
   outro,
@@ -30,9 +29,11 @@ import {
   cancel,
   isCancel,
   log,
+  spinner,
 } from '@clack/prompts';
 import { checkGhostUrl, checkGhostKey } from './validation.js';
 import { ALL_CLIENTS } from './setup/clients/index.js';
+import { run } from './setup/process.js';
 import { detect, read, write, SERVER_NAME } from './setup/dispatch.js';
 import { classify, resolveCanonical } from './setup/classify.js';
 import { McpClient, ClientState, GhostEnv } from './setup/types.js';
@@ -45,15 +46,20 @@ const REPO_URL = `https://github.com/${REPO}`;
 const HOME = os.homedir();
 const STAR_MARKER = path.join(HOME, '.config', 'ghost-mcp', '.star-prompted');
 
+// Calm line spinner (| / - \) at a relaxed cadence, instead of clack's default
+// fast ◒◐◓◑ rotation which reads as busy.
+const SPINNER_FRAMES = ['|', '/', '-', '\\'];
+const SPINNER_DELAY = 180;
+
 type ScanRow = { client: McpClient; state: ClientState };
 
-function scan(): ScanRow[] {
-  const detected = ALL_CLIENTS.filter(detect);
+// Probe one client. Returns null if its CLI is not installed, otherwise the
+// current registration state (classified against a stub env — adapters mask env,
+// so only command/args drift matters until the user supplies the canonical env).
+async function probe(client: McpClient): Promise<ClientState | null> {
+  if (!(await detect(client))) return null;
   const stub: GhostEnv = { GHOST_URL: '', GHOST_ADMIN_API_KEY: '' };
-  return detected.map((client) => ({
-    client,
-    state: classify(stub, read(client)),
-  }));
+  return classify(stub, await read(client));
 }
 
 function reclassify(rows: ScanRow[], canonical: GhostEnv): ScanRow[] {
@@ -79,13 +85,6 @@ function summary(state: ClientState): string {
   }
 }
 
-function renderRows(rows: ScanRow[]): void {
-  const lines = rows.map(({ client, state }) =>
-    `  ${symbol(state)}  ${client.label.padEnd(14)}  ${summary(state)}`
-  );
-  note(lines.join('\n'), 'MCP clients');
-}
-
 function bail(msg: string): never {
   cancel(msg);
   process.exit(0);
@@ -96,14 +95,12 @@ function check<T>(value: T | symbol): T {
   return value as T;
 }
 
-function ghAvailable(): boolean {
-  const r = spawnSync('gh', ['--version'], { stdio: 'ignore' });
-  return r.status === 0;
+async function ghAvailable(): Promise<boolean> {
+  return (await run('gh', ['--version'], { stdio: 'ignore' })).status === 0;
 }
 
-function ghAuthed(): boolean {
-  const r = spawnSync('gh', ['auth', 'status'], { stdio: 'ignore' });
-  return r.status === 0;
+async function ghAuthed(): Promise<boolean> {
+  return (await run('gh', ['auth', 'status'], { stdio: 'ignore' })).status === 0;
 }
 
 function markStarPrompted(): void {
@@ -115,12 +112,12 @@ function markStarPrompted(): void {
   }
 }
 
-function tryStar(): void {
-  if (!ghAvailable()) {
+async function tryStar(): Promise<void> {
+  if (!(await ghAvailable())) {
     log.info(`\`gh\` CLI not found. Star manually at:\n  ${REPO_URL}`);
     return;
   }
-  if (!ghAuthed()) {
+  if (!(await ghAuthed())) {
     log.info(
       `\`gh\` not authenticated. Run \`gh auth login\` then star at:\n  ${REPO_URL}`
     );
@@ -129,7 +126,7 @@ function tryStar(): void {
 
   // `gh repo star` subcommand does not exist. Use the REST API directly:
   // PUT /user/starred/{owner}/{repo}.
-  const r = spawnSync(
+  const r = await run(
     'gh',
     ['api', '--method', 'PUT', '--silent', `/user/starred/${REPO}`],
     { stdio: ['ignore', 'ignore', 'ignore'] }
@@ -150,7 +147,7 @@ interface StarFlags {
 async function offerStar(flags: StarFlags): Promise<void> {
   // --star: explicit opt-in, no prompt (dotfiles / CI consent)
   if (flags.star) {
-    tryStar();
+    await tryStar();
     markStarPrompted();
     return;
   }
@@ -189,8 +186,26 @@ export async function runSetup(): Promise<void> {
   // 1. Intro
   intro('ghost-mcp setup');
 
-  // 2. SCAN — detect all installed MCP CLIs and their current registration state
-  const rows = scan();
+  // 2. SCAN — probe each supported client one at a time, reporting progress.
+  // Each probe is an async CLI spawn (claude --version, mcp list, …), so a
+  // per-client spinner gives a live "checking X… → result" trail instead of a
+  // silent pause. Not-installed clients are shown too, then dropped from `rows`.
+  const rows: ScanRow[] = [];
+  const total = ALL_CLIENTS.length;
+  for (let i = 0; i < total; i++) {
+    const client = ALL_CLIENTS[i];
+    const s = spinner({ frames: SPINNER_FRAMES, delay: SPINNER_DELAY });
+    s.start(`[${i + 1}/${total}] Checking ${client.label}…`);
+    // await yields the event loop while the CLI probe runs, so the spinner
+    // actually animates instead of freezing (the whole point of going async).
+    const state = await probe(client);
+    if (state === null) {
+      s.stop(`—  ${client.label}: not installed`);
+      continue;
+    }
+    rows.push({ client, state });
+    s.stop(`${symbol(state)}  ${client.label}: ${summary(state)}`);
+  }
 
   if (rows.length === 0) {
     note(
@@ -200,8 +215,6 @@ export async function runSetup(): Promise<void> {
     outro('No changes made.');
     return;
   }
-
-  renderRows(rows);
 
   // 3. RESOLVE CANONICAL (initial) — from any in-sync entries
   const inSyncEnvs = rows
@@ -276,7 +289,7 @@ export async function runSetup(): Promise<void> {
 
   const selected = check(
     await multiselect({
-      message: 'Apply to',
+      message: 'Apply to (space to toggle, enter to confirm)',
       options,
       initialValues: options.map((o) => o.value),
       required: false,
@@ -297,7 +310,9 @@ export async function runSetup(): Promise<void> {
       continue;
     }
     try {
-      write(client, canonical, SERVER_NAME);
+      // Stale entries pass replace=true so write removes the differing entry
+      // before re-adding (most CLIs' `mcp add` refuses to overwrite).
+      await write(client, canonical, SERVER_NAME, { replace: state.kind === 'stale' });
       applied++;
     } catch (e) {
       failures.push({ client, error: e });

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -284,7 +284,7 @@ export async function runSetup(): Promise<void> {
     .map((r) => ({
       value: r.client.id,
       label: `${r.client.label} (${summary(r.state)})`,
-      hint: r.state.kind === 'in-sync' ? 'skip — already in-sync' : undefined,
+      hint: r.state.kind === 'in-sync' ? 'in-sync (uncheck to skip)' : undefined,
     }));
 
   const selected = check(

--- a/src/setup/classify.test.ts
+++ b/src/setup/classify.test.ts
@@ -1,0 +1,199 @@
+/** @covers src/setup/classify.ts */
+import { describe, it, expect } from 'vitest';
+import { classify, resolveCanonical } from './classify.js';
+import { GhostEnv, RegisteredEntry } from './types.js';
+
+describe('classify', () => {
+  const canonical: GhostEnv = {
+    GHOST_URL: 'https://blog.example.com',
+    GHOST_ADMIN_API_KEY: 'key:secret123',
+  };
+
+  it('returns in-sync when command/args/env all match canonical', () => {
+    const entry: RegisteredEntry = {
+      command: 'npx',
+      args: ['-y', '@uppinote/ghost-mcp@latest'],
+      env: {
+        GHOST_URL: 'https://blog.example.com',
+        GHOST_ADMIN_API_KEY: 'key:secret123',
+      },
+    };
+
+    const state = classify(canonical, entry);
+    expect(state.kind).toBe('in-sync');
+    if (state.kind === 'in-sync') {
+      expect(state.entry).toBe(entry);
+    }
+  });
+
+  it('returns stale when GHOST_URL differs', () => {
+    const entry: RegisteredEntry = {
+      command: 'npx',
+      args: ['-y', '@uppinote/ghost-mcp@latest'],
+      env: {
+        GHOST_URL: 'https://old-blog.example.com',
+        GHOST_ADMIN_API_KEY: 'key:secret123',
+      },
+    };
+
+    const state = classify(canonical, entry);
+    expect(state.kind).toBe('stale');
+    if (state.kind === 'stale') {
+      expect(state.reasons.join(' ')).toMatch(/GHOST_URL/);
+      expect(state.reasons.join(' ')).toMatch(/old-blog\.example\.com/);
+    }
+  });
+
+  it('returns stale when GHOST_ADMIN_API_KEY differs', () => {
+    const entry: RegisteredEntry = {
+      command: 'npx',
+      args: ['-y', '@uppinote/ghost-mcp@latest'],
+      env: {
+        GHOST_URL: 'https://blog.example.com',
+        GHOST_ADMIN_API_KEY: 'key:oldSecret',
+      },
+    };
+
+    const state = classify(canonical, entry);
+    expect(state.kind).toBe('stale');
+    if (state.kind === 'stale') {
+      expect(state.reasons.join(' ')).toMatch(/GHOST_ADMIN_API_KEY/);
+    }
+  });
+
+  it('returns stale when command differs (dev-clone: command=node)', () => {
+    const entry: RegisteredEntry = {
+      command: 'node',
+      args: ['/path/dist/index.js'],
+      env: {
+        GHOST_URL: 'https://blog.example.com',
+        GHOST_ADMIN_API_KEY: 'key:secret123',
+      },
+    };
+
+    const state = classify(canonical, entry);
+    expect(state.kind).toBe('stale');
+    if (state.kind === 'stale') {
+      expect(state.reasons.join(' ')).toMatch(/command/);
+      expect(state.reasons.join(' ')).toMatch(/node/);
+    }
+  });
+
+  it('returns stale when args differ (pinned version)', () => {
+    const entry: RegisteredEntry = {
+      command: 'npx',
+      args: ['-y', '@uppinote/ghost-mcp@1.1.0'],
+      env: {
+        GHOST_URL: 'https://blog.example.com',
+        GHOST_ADMIN_API_KEY: 'key:secret123',
+      },
+    };
+
+    const state = classify(canonical, entry);
+    expect(state.kind).toBe('stale');
+    if (state.kind === 'stale') {
+      expect(state.reasons.join(' ')).toMatch(/args/);
+      expect(state.reasons.join(' ')).toMatch(/1\.1\.0/);
+    }
+  });
+
+  it('returns missing when entry is null', () => {
+    const state = classify(canonical, null);
+    expect(state.kind).toBe('missing');
+  });
+
+  it('returns in-sync when entry.env is empty {} and command/args match (design pivot case)', () => {
+    const entry: RegisteredEntry = {
+      command: 'npx',
+      args: ['-y', '@uppinote/ghost-mcp@latest'],
+      env: {},
+    };
+
+    const state = classify(canonical, entry);
+    expect(state.kind).toBe('in-sync');
+    if (state.kind === 'in-sync') {
+      expect(state.entry).toBe(entry);
+    }
+  });
+
+  it('accumulates multiple diff reasons when multiple fields differ', () => {
+    const entry: RegisteredEntry = {
+      command: 'node',
+      args: ['/path/dist/index.js'],
+      env: {
+        GHOST_URL: 'https://old-blog.example.com',
+        GHOST_ADMIN_API_KEY: 'key:oldSecret',
+      },
+    };
+
+    const state = classify(canonical, entry);
+    expect(state.kind).toBe('stale');
+    if (state.kind === 'stale') {
+      expect(state.reasons.length).toBeGreaterThan(1);
+      const combined = state.reasons.join(' ');
+      expect(combined).toMatch(/command/);
+      expect(combined).toMatch(/args/);
+      expect(combined).toMatch(/GHOST_URL/);
+      expect(combined).toMatch(/GHOST_ADMIN_API_KEY/);
+    }
+  });
+});
+
+describe('resolveCanonical', () => {
+  it('returns null on empty input', () => {
+    const result = resolveCanonical([]);
+    expect(result).toBeNull();
+  });
+
+  it('returns the unique value when all entries agree', () => {
+    const env1: GhostEnv = {
+      GHOST_URL: 'https://blog.example.com',
+      GHOST_ADMIN_API_KEY: 'key:secret123',
+    };
+    const env2: GhostEnv = {
+      GHOST_URL: 'https://blog.example.com',
+      GHOST_ADMIN_API_KEY: 'key:secret123',
+    };
+
+    const result = resolveCanonical([env1, env2]);
+    expect(result).toEqual(env1);
+  });
+
+  it('returns "conflict" when entries disagree on GHOST_URL', () => {
+    const env1: GhostEnv = {
+      GHOST_URL: 'https://blog.example.com',
+      GHOST_ADMIN_API_KEY: 'key:secret123',
+    };
+    const env2: GhostEnv = {
+      GHOST_URL: 'https://other-blog.example.com',
+      GHOST_ADMIN_API_KEY: 'key:secret123',
+    };
+
+    const result = resolveCanonical([env1, env2]);
+    expect(result).toBe('conflict');
+  });
+
+  it('returns "conflict" when entries disagree on GHOST_ADMIN_API_KEY', () => {
+    const env1: GhostEnv = {
+      GHOST_URL: 'https://blog.example.com',
+      GHOST_ADMIN_API_KEY: 'key:secret123',
+    };
+    const env2: GhostEnv = {
+      GHOST_URL: 'https://blog.example.com',
+      GHOST_ADMIN_API_KEY: 'key:otherSecret',
+    };
+
+    const result = resolveCanonical([env1, env2]);
+    expect(result).toBe('conflict');
+  });
+
+  it('returns the single entry when input has only one element', () => {
+    const env: GhostEnv = {
+      GHOST_URL: 'https://blog.example.com',
+      GHOST_ADMIN_API_KEY: 'key:secret123',
+    };
+
+    const result = resolveCanonical([env]);
+    expect(result).toEqual(env);
+  });
+});

--- a/src/setup/classify.ts
+++ b/src/setup/classify.ts
@@ -1,0 +1,69 @@
+/**
+ * State classification + canonical value resolution.
+ *
+ * classify(canonical, entry) → in-sync | stale (with diff reasons) | missing
+ * resolveCanonical(envs) → unique GhostEnv | 'conflict' | null
+ *
+ * env comparison is conditional: if the adapter returned env={} (Claude Code,
+ * Codex, Gemini all mask env), we skip env comparison entirely — drift falls
+ * back to command/args, which IS extractable from CLI output. The wizard
+ * always writes fresh env values regardless of drift state, so this conservative
+ * env handling is safe.
+ *
+ * @handbook 2.4-setup-wizard
+ */
+import { ClientState, GhostEnv, RegisteredEntry } from './types.js';
+import { CANONICAL_CMD, CANONICAL_ARGS } from './dispatch.js';
+
+function arraysEqual(a: readonly string[], b: readonly string[]): boolean {
+  return a.length === b.length && a.every((v, i) => v === b[i]);
+}
+
+export function classify(
+  canonical: GhostEnv,
+  entry: RegisteredEntry | null
+): ClientState {
+  if (entry === null) return { kind: 'missing' };
+
+  const reasons: string[] = [];
+
+  if (entry.command !== CANONICAL_CMD) {
+    reasons.push(`command is "${entry.command}" (expected "${CANONICAL_CMD}")`);
+  }
+  if (!arraysEqual(entry.args, CANONICAL_ARGS)) {
+    reasons.push(
+      `args are [${entry.args.join(', ')}] (expected [${CANONICAL_ARGS.join(', ')}])`
+    );
+  }
+  if (
+    entry.env.GHOST_URL !== undefined &&
+    entry.env.GHOST_URL !== canonical.GHOST_URL
+  ) {
+    reasons.push(
+      `env.GHOST_URL is "${entry.env.GHOST_URL}" (expected "${canonical.GHOST_URL}")`
+    );
+  }
+  if (
+    entry.env.GHOST_ADMIN_API_KEY !== undefined &&
+    entry.env.GHOST_ADMIN_API_KEY !== canonical.GHOST_ADMIN_API_KEY
+  ) {
+    reasons.push('env.GHOST_ADMIN_API_KEY differs from canonical');
+  }
+
+  return reasons.length === 0
+    ? { kind: 'in-sync', entry }
+    : { kind: 'stale', entry, reasons };
+}
+
+export type CanonicalResult = GhostEnv | 'conflict' | null;
+
+export function resolveCanonical(envs: GhostEnv[]): CanonicalResult {
+  if (envs.length === 0) return null;
+  const first = envs[0];
+  const allAgree = envs.every(
+    (e) =>
+      e.GHOST_URL === first.GHOST_URL &&
+      e.GHOST_ADMIN_API_KEY === first.GHOST_ADMIN_API_KEY
+  );
+  return allAgree ? first : 'conflict';
+}

--- a/src/setup/classify.ts
+++ b/src/setup/classify.ts
@@ -10,7 +10,8 @@
  * always writes fresh env values regardless of drift state, so this conservative
  * env handling is safe.
  *
- * @handbook 2.4-setup-wizard
+ * @handbook 2.5-client-adapters
+ * @tested src/setup/classify.test.ts
  */
 import { ClientState, GhostEnv, RegisteredEntry } from './types.js';
 import { CANONICAL_CMD, CANONICAL_ARGS } from './dispatch.js';

--- a/src/setup/clients/claude-code.test.ts
+++ b/src/setup/clients/claude-code.test.ts
@@ -1,0 +1,80 @@
+/** @covers src/setup/clients/claude-code.ts */
+import { describe, it, expect } from 'vitest';
+import { claudeCode } from './claude-code.js';
+
+describe('claudeCode adapter', () => {
+  describe('addArgs', () => {
+    it('generates correct argv for mcp add with env flags and user scope', () => {
+      const result = claudeCode.addArgs('ghost-blog', {
+        GHOST_URL: 'https://blog.example.com',
+        GHOST_ADMIN_API_KEY: 'id:secret',
+      }, 'npx', ['-y', '@uppinote/ghost-mcp@latest']);
+
+      expect(result).toEqual([
+        'mcp', 'add',
+        '-s', 'user',
+        '-e', 'GHOST_URL=https://blog.example.com',
+        '-e', 'GHOST_ADMIN_API_KEY=id:secret',
+        'ghost-blog',
+        '--',
+        'npx', '-y', '@uppinote/ghost-mcp@latest',
+      ]);
+    });
+  });
+
+  describe('listArgs', () => {
+    it('generates correct argv for mcp list', () => {
+      const result = claudeCode.listArgs();
+      expect(result).toEqual(['mcp', 'list']);
+    });
+  });
+
+  describe('getArgs', () => {
+    it('generates correct argv for mcp get with --json flag', () => {
+      const result = claudeCode.getArgs('ghost-blog');
+      expect(result).toEqual(['mcp', 'get', 'ghost-blog', '--json']);
+    });
+  });
+
+  describe('removeArgs', () => {
+    it('generates correct argv for mcp remove with user scope', () => {
+      const result = claudeCode.removeArgs('ghost-blog');
+      expect(result).toEqual(['mcp', 'remove', '-s', 'user', 'ghost-blog']);
+    });
+  });
+
+  describe('parseGet', () => {
+    it('parses valid JSON with command field and returns RegisteredEntry', () => {
+      const stdout = JSON.stringify({
+        name: 'ghost-blog',
+        type: 'stdio',
+        command: 'npx',
+        args: ['-y', '@uppinote/ghost-mcp@latest'],
+        env: {
+          GHOST_URL: 'https://blog.example.com',
+          GHOST_ADMIN_API_KEY: 'id:secret',
+        },
+      });
+
+      const result = claudeCode.parseGet(stdout, 'ghost-blog');
+      expect(result).toEqual({
+        command: 'npx',
+        args: ['-y', '@uppinote/ghost-mcp@latest'],
+        env: {
+          GHOST_URL: 'https://blog.example.com',
+          GHOST_ADMIN_API_KEY: 'id:secret',
+        },
+      });
+    });
+
+    it('returns null for empty stdout', () => {
+      const result = claudeCode.parseGet('', 'ghost-blog');
+      expect(result).toBeNull();
+    });
+
+    it('returns null for non-JSON stdout', () => {
+      const result = claudeCode.parseGet('No MCP server found.', 'ghost-blog');
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/src/setup/clients/claude-code.test.ts
+++ b/src/setup/clients/claude-code.test.ts
@@ -2,13 +2,28 @@
 import { describe, it, expect } from 'vitest';
 import { claudeCode } from './claude-code.js';
 
+// Fixture mirrors real `claude mcp list` output captured from a working install.
+// Contains: target stdio entry, another stdio entry, and an HTTP entry to verify
+// the parser skips HTTP and picks the right name.
+const LIST_FIXTURE = `Checking MCP server health…
+
+plugin:context7:context7: npx -y @upstash/context7-mcp - ✓ Connected
+plugin:sentry:sentry: https://mcp.sentry.dev/mcp (HTTP) - ! Needs authentication
+ghost-blog: npx -y @uppinote/ghost-mcp@latest - ✓ Connected
+nanobanana: node /Users/kim/.gemini/extensions/nanobanana/mcp-server/dist/index.js - ✓ Connected
+`;
+
+const DEV_CLONE_FIXTURE = `ghost-blog: node /Users/kim/Desktop/Project/_shipped/ghost-mcp/dist/index.js - ✓ Connected\n`;
+
 describe('claudeCode adapter', () => {
   describe('addArgs', () => {
-    it('generates correct argv for mcp add with env flags and user scope', () => {
-      const result = claudeCode.addArgs('ghost-blog', {
-        GHOST_URL: 'https://blog.example.com',
-        GHOST_ADMIN_API_KEY: 'id:secret',
-      }, 'npx', ['-y', '@uppinote/ghost-mcp@latest']);
+    it('generates user-scoped argv with -e env flags and -- separator', () => {
+      const result = claudeCode.addArgs(
+        'ghost-blog',
+        { GHOST_URL: 'https://blog.example.com', GHOST_ADMIN_API_KEY: 'id:secret' },
+        'npx',
+        ['-y', '@uppinote/ghost-mcp@latest']
+      );
 
       expect(result).toEqual([
         'mcp', 'add',
@@ -23,58 +38,60 @@ describe('claudeCode adapter', () => {
   });
 
   describe('listArgs', () => {
-    it('generates correct argv for mcp list', () => {
-      const result = claudeCode.listArgs();
-      expect(result).toEqual(['mcp', 'list']);
+    it('returns mcp list argv', () => {
+      expect(claudeCode.listArgs()).toEqual(['mcp', 'list']);
     });
   });
 
   describe('getArgs', () => {
-    it('generates correct argv for mcp get with --json flag', () => {
-      const result = claudeCode.getArgs('ghost-blog');
-      expect(result).toEqual(['mcp', 'get', 'ghost-blog', '--json']);
+    it('delegates to mcp list because the CLI mcp get omits config detail', () => {
+      expect(claudeCode.getArgs('ghost-blog')).toEqual(['mcp', 'list']);
     });
   });
 
   describe('removeArgs', () => {
-    it('generates correct argv for mcp remove with user scope', () => {
-      const result = claudeCode.removeArgs('ghost-blog');
-      expect(result).toEqual(['mcp', 'remove', '-s', 'user', 'ghost-blog']);
+    it('uses -s user scope to target the same registration as add', () => {
+      expect(claudeCode.removeArgs('ghost-blog')).toEqual([
+        'mcp', 'remove', '-s', 'user', 'ghost-blog',
+      ]);
     });
   });
 
   describe('parseGet', () => {
-    it('parses valid JSON with command field and returns RegisteredEntry', () => {
-      const stdout = JSON.stringify({
-        name: 'ghost-blog',
-        type: 'stdio',
-        command: 'npx',
-        args: ['-y', '@uppinote/ghost-mcp@latest'],
-        env: {
-          GHOST_URL: 'https://blog.example.com',
-          GHOST_ADMIN_API_KEY: 'id:secret',
-        },
-      });
-
-      const result = claudeCode.parseGet(stdout, 'ghost-blog');
+    it('extracts command and args for the target name from list output', () => {
+      const result = claudeCode.parseGet(LIST_FIXTURE, 'ghost-blog');
       expect(result).toEqual({
         command: 'npx',
         args: ['-y', '@uppinote/ghost-mcp@latest'],
-        env: {
-          GHOST_URL: 'https://blog.example.com',
-          GHOST_ADMIN_API_KEY: 'id:secret',
-        },
+        env: {},
       });
     });
 
-    it('returns null for empty stdout', () => {
-      const result = claudeCode.parseGet('', 'ghost-blog');
-      expect(result).toBeNull();
+    it('extracts dev-clone style command + path arg (the v1.0.x migration case)', () => {
+      const result = claudeCode.parseGet(DEV_CLONE_FIXTURE, 'ghost-blog');
+      expect(result).toEqual({
+        command: 'node',
+        args: ['/Users/kim/Desktop/Project/_shipped/ghost-mcp/dist/index.js'],
+        env: {},
+      });
     });
 
-    it('returns null for non-JSON stdout', () => {
-      const result = claudeCode.parseGet('No MCP server found.', 'ghost-blog');
-      expect(result).toBeNull();
+    it('always leaves env empty because Claude Code masks env in list output', () => {
+      const result = claudeCode.parseGet(LIST_FIXTURE, 'ghost-blog');
+      expect(result?.env).toEqual({});
+    });
+
+    it('returns null when the target name is absent from the list', () => {
+      expect(claudeCode.parseGet(LIST_FIXTURE, 'not-registered')).toBeNull();
+    });
+
+    it('returns null for empty stdout', () => {
+      expect(claudeCode.parseGet('', 'ghost-blog')).toBeNull();
+    });
+
+    it('returns null when the target line is an HTTP entry (not stdio)', () => {
+      const httpFixture = `ghost-blog: https://example.com/mcp (HTTP) - ✓ Connected\n`;
+      expect(claudeCode.parseGet(httpFixture, 'ghost-blog')).toBeNull();
     });
   });
 });

--- a/src/setup/clients/claude-code.test.ts
+++ b/src/setup/clients/claude-code.test.ts
@@ -1,23 +1,13 @@
 /** @covers src/setup/clients/claude-code.ts */
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import fs from 'node:fs';
 import { claudeCode } from './claude-code.js';
 
-// Fixture mirrors real `claude mcp list` output captured from a working install.
-// Contains: target stdio entry, another stdio entry, and an HTTP entry to verify
-// the parser skips HTTP and picks the right name.
-const LIST_FIXTURE = `Checking MCP server health…
-
-plugin:context7:context7: npx -y @upstash/context7-mcp - ✓ Connected
-plugin:sentry:sentry: https://mcp.sentry.dev/mcp (HTTP) - ! Needs authentication
-ghost-blog: npx -y @uppinote/ghost-mcp@latest - ✓ Connected
-nanobanana: node /Users/kim/.gemini/extensions/nanobanana/mcp-server/dist/index.js - ✓ Connected
-`;
-
-const DEV_CLONE_FIXTURE = `ghost-blog: node /Users/kim/Desktop/Project/_shipped/ghost-mcp/dist/index.js - ✓ Connected\n`;
+afterEach(() => vi.restoreAllMocks());
 
 describe('claudeCode adapter', () => {
   describe('addArgs', () => {
-    it('generates user-scoped argv with -e env flags and -- separator', () => {
+    it('puts the name before the variadic -e flags so it is not consumed as env', () => {
       const result = claudeCode.addArgs(
         'ghost-blog',
         { GHOST_URL: 'https://blog.example.com', GHOST_ADMIN_API_KEY: 'id:secret' },
@@ -25,21 +15,17 @@ describe('claudeCode adapter', () => {
         ['-y', '@uppinote/ghost-mcp@latest']
       );
 
+      // claude's `-e, --env <env...>` is variadic: a name placed after the last
+      // -e is swallowed as an env value. name must precede -e; -- ends the variadic.
       expect(result).toEqual([
         'mcp', 'add',
         '-s', 'user',
+        'ghost-blog',
         '-e', 'GHOST_URL=https://blog.example.com',
         '-e', 'GHOST_ADMIN_API_KEY=id:secret',
-        'ghost-blog',
         '--',
         'npx', '-y', '@uppinote/ghost-mcp@latest',
       ]);
-    });
-  });
-
-  describe('getArgs', () => {
-    it('delegates to mcp list because the CLI mcp get omits config detail', () => {
-      expect(claudeCode.getArgs('ghost-blog')).toEqual(['mcp', 'list']);
     });
   });
 
@@ -51,41 +37,22 @@ describe('claudeCode adapter', () => {
     });
   });
 
-  describe('parseGet', () => {
-    it('extracts command and args for the target name from list output', () => {
-      const result = claudeCode.parseGet(LIST_FIXTURE, 'ghost-blog');
-      expect(result).toEqual({
+  // Edge cases (missing/malformed/absent) live in json-config.test.ts; here we
+  // just confirm claude wires the right user-scope config path.
+  describe('readEntry', () => {
+    it('reads ~/.claude.json user-scope mcpServers for the target server', () => {
+      const spy = vi.spyOn(fs, 'readFileSync').mockReturnValue(
+        JSON.stringify({
+          mcpServers: { 'ghost-blog': { command: 'npx', args: ['-y', '@uppinote/ghost-mcp@latest'] } },
+        })
+      );
+
+      expect(claudeCode.readEntry!('ghost-blog')).toEqual({
         command: 'npx',
         args: ['-y', '@uppinote/ghost-mcp@latest'],
         env: {},
       });
-    });
-
-    it('extracts dev-clone style command + path arg (the v1.0.x migration case)', () => {
-      const result = claudeCode.parseGet(DEV_CLONE_FIXTURE, 'ghost-blog');
-      expect(result).toEqual({
-        command: 'node',
-        args: ['/Users/kim/Desktop/Project/_shipped/ghost-mcp/dist/index.js'],
-        env: {},
-      });
-    });
-
-    it('always leaves env empty because Claude Code masks env in list output', () => {
-      const result = claudeCode.parseGet(LIST_FIXTURE, 'ghost-blog');
-      expect(result?.env).toEqual({});
-    });
-
-    it('returns null when the target name is absent from the list', () => {
-      expect(claudeCode.parseGet(LIST_FIXTURE, 'not-registered')).toBeNull();
-    });
-
-    it('returns null for empty stdout', () => {
-      expect(claudeCode.parseGet('', 'ghost-blog')).toBeNull();
-    });
-
-    it('returns null when the target line is an HTTP entry (not stdio)', () => {
-      const httpFixture = `ghost-blog: https://example.com/mcp (HTTP) - ✓ Connected\n`;
-      expect(claudeCode.parseGet(httpFixture, 'ghost-blog')).toBeNull();
+      expect(String(spy.mock.calls[0]?.[0])).toMatch(/\.claude\.json$/);
     });
   });
 });

--- a/src/setup/clients/claude-code.test.ts
+++ b/src/setup/clients/claude-code.test.ts
@@ -37,12 +37,6 @@ describe('claudeCode adapter', () => {
     });
   });
 
-  describe('listArgs', () => {
-    it('returns mcp list argv', () => {
-      expect(claudeCode.listArgs()).toEqual(['mcp', 'list']);
-    });
-  });
-
   describe('getArgs', () => {
     it('delegates to mcp list because the CLI mcp get omits config detail', () => {
       expect(claudeCode.getArgs('ghost-blog')).toEqual(['mcp', 'list']);

--- a/src/setup/clients/claude-code.ts
+++ b/src/setup/clients/claude-code.ts
@@ -1,16 +1,22 @@
 /**
- * Claude Code MCP adapter — wraps `claude mcp add/list/remove`.
+ * Claude Code MCP adapter — writes via `claude mcp add/remove`, but reads
+ * registration state from ~/.claude.json directly.
  *
- * Note: `claude mcp get` only prints scope + status; it does not expose
- * command, args, or env. `claude mcp list` exposes each server's command and
- * args inline but masks env. So we use `mcp list` for read, filter to the
- * target name, and leave env empty — drift on env cannot be detected from this
- * CLI surface, only on command/args (e.g. an old dev-clone
- * `node /path/.../dist/index.js` vs the canonical npx invocation).
+ * READ is file-based, not CLI-based. `claude mcp list` reports the *effective*
+ * server (the highest-precedence scope), which can be a project/.mcp.json entry
+ * — but the wizard only ever writes user scope (`-s user`). Reading the
+ * effective scope makes the wizard misread a project override as "stale", then
+ * fail to "fix" it: `mcp add -s user` errors "already exists" against the user
+ * entry the effective read couldn't see. readEntry parses ~/.claude.json's
+ * user-scope mcpServers instead, so read and write target the same scope. Writes
+ * still go through the CLI (`mcp add` is fine).
  *
  * @handbook 2.5-client-adapters
  * @tested src/setup/clients/claude-code.test.ts
  */
+import os from 'node:os';
+import path from 'node:path';
+import { readFromJsonConfig } from './json-config.js';
 import { McpClient, RegisteredEntry, GhostEnv } from '../types.js';
 
 export const claudeCode: McpClient = {
@@ -24,58 +30,35 @@ export const claudeCode: McpClient = {
     cmd: string,
     cmdArgs: string[]
   ): string[] {
+    // `name` MUST precede the -e flags. claude's `-e, --env <env...>` is variadic,
+    // so a positional placed after the last -e is swallowed as an env value
+    // ("Invalid environment variable format: <name>"). The `--` then terminates
+    // the variadic so the command/args are not consumed either.
+    // Canonical: claude mcp add [-s user] <name> -e KEY=val -- <cmd> <args...>
     return [
       'mcp',
       'add',
       '-s',
       'user',
+      name,
       '-e',
       `GHOST_URL=${env.GHOST_URL}`,
       '-e',
       `GHOST_ADMIN_API_KEY=${env.GHOST_ADMIN_API_KEY}`,
-      name,
       '--',
       cmd,
       ...cmdArgs,
     ];
   },
 
-  // Delegates to `mcp list` and then filters by name in parseGet.
-  // `mcp get` cannot be used because the current Claude Code release emits
-  // human-readable text without the command/args/env fields.
-  getArgs(_name: string): string[] {
-    return ['mcp', 'list'];
-  },
-
   removeArgs(name: string): string[] {
     return ['mcp', 'remove', '-s', 'user', name];
   },
 
-  parseGet(stdout: string, name: string): RegisteredEntry | null {
-    if (!stdout) return null;
-
-    // `mcp list` line shape (stdio):
-    //   <name>: <command> [<arg> ...] - <status emoji + text>
-    // HTTP entries end with "(HTTP)" or start with http(s)://; we skip those.
-    const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-    const linePattern = new RegExp(`^${escaped}:\\s+(.+?)\\s+-\\s+`, 'm');
-
-    const match = stdout.match(linePattern);
-    if (!match) return null;
-
-    const cmdAndArgs = match[1].trim();
-    if (/\(HTTP\)$/.test(cmdAndArgs) || /^https?:\/\//.test(cmdAndArgs)) {
-      return null;
-    }
-
-    const tokens = cmdAndArgs.split(/\s+/);
-    const command = tokens[0];
-    if (!command) return null;
-    const args = tokens.slice(1);
-
-    // env is intentionally empty — Claude Code masks it. classify treats an
-    // empty registered env as "in-sync on env" so the wizard still detects
-    // command/args drift (the v1.0.x → npx migration case).
-    return { command, args, env: {} };
+  // Reads ~/.claude.json user-scope mcpServers — see the file header for why
+  // `claude mcp list` (effective scope) is the wrong source for a wizard that
+  // writes user scope.
+  readEntry(name: string): RegisteredEntry | null {
+    return readFromJsonConfig(path.join(os.homedir(), '.claude.json'), name);
   },
 };

--- a/src/setup/clients/claude-code.ts
+++ b/src/setup/clients/claude-code.ts
@@ -39,10 +39,6 @@ export const claudeCode: McpClient = {
     ];
   },
 
-  listArgs(): string[] {
-    return ['mcp', 'list'];
-  },
-
   // Delegates to `mcp list` and then filters by name in parseGet.
   // `mcp get` cannot be used because the current Claude Code release emits
   // human-readable text without the command/args/env fields.

--- a/src/setup/clients/claude-code.ts
+++ b/src/setup/clients/claude-code.ts
@@ -8,7 +8,8 @@
  * CLI surface, only on command/args (e.g. an old dev-clone
  * `node /path/.../dist/index.js` vs the canonical npx invocation).
  *
- * @handbook 2.4-setup-wizard
+ * @handbook 2.5-client-adapters
+ * @tested src/setup/clients/claude-code.test.ts
  */
 import { McpClient, RegisteredEntry, GhostEnv } from '../types.js';
 

--- a/src/setup/clients/claude-code.ts
+++ b/src/setup/clients/claude-code.ts
@@ -1,12 +1,12 @@
 /**
  * Claude Code MCP adapter — wraps `claude mcp add/list/remove`.
  *
- * Note: Claude Code's `mcp get` is human-readable text and does NOT expose env
- * vars (security masking). `mcp list` exposes each server's command and args
- * inline but also masks env. So we use `mcp list` for read, filter to the
+ * Note: `claude mcp get` only prints scope + status; it does not expose
+ * command, args, or env. `claude mcp list` exposes each server's command and
+ * args inline but masks env. So we use `mcp list` for read, filter to the
  * target name, and leave env empty — drift on env cannot be detected from this
- * CLI surface, only on command/args (e.g. an old dev-clone `node /path/.../
- * dist/index.js` vs the canonical npx invocation).
+ * CLI surface, only on command/args (e.g. an old dev-clone
+ * `node /path/.../dist/index.js` vs the canonical npx invocation).
  *
  * @handbook 2.4-setup-wizard
  */
@@ -55,7 +55,7 @@ export const claudeCode: McpClient = {
   },
 
   parseGet(stdout: string, name: string): RegisteredEntry | null {
-    if (!stdout || typeof stdout !== 'string') return null;
+    if (!stdout) return null;
 
     // `mcp list` line shape (stdio):
     //   <name>: <command> [<arg> ...] - <status emoji + text>
@@ -73,6 +73,7 @@ export const claudeCode: McpClient = {
 
     const tokens = cmdAndArgs.split(/\s+/);
     const command = tokens[0];
+    if (!command) return null;
     const args = tokens.slice(1);
 
     // env is intentionally empty — Claude Code masks it. classify treats an

--- a/src/setup/clients/claude-code.ts
+++ b/src/setup/clients/claude-code.ts
@@ -1,5 +1,12 @@
 /**
- * Claude Code MCP adapter — wraps `claude mcp add/list/get/remove`.
+ * Claude Code MCP adapter — wraps `claude mcp add/list/remove`.
+ *
+ * Note: Claude Code's `mcp get` is human-readable text and does NOT expose env
+ * vars (security masking). `mcp list` exposes each server's command and args
+ * inline but also masks env. So we use `mcp list` for read, filter to the
+ * target name, and leave env empty — drift on env cannot be detected from this
+ * CLI surface, only on command/args (e.g. an old dev-clone `node /path/.../
+ * dist/index.js` vs the canonical npx invocation).
  *
  * @handbook 2.4-setup-wizard
  */
@@ -36,44 +43,41 @@ export const claudeCode: McpClient = {
     return ['mcp', 'list'];
   },
 
-  getArgs(name: string): string[] {
-    return ['mcp', 'get', name, '--json'];
+  // Delegates to `mcp list` and then filters by name in parseGet.
+  // `mcp get` cannot be used because the current Claude Code release emits
+  // human-readable text without the command/args/env fields.
+  getArgs(_name: string): string[] {
+    return ['mcp', 'list'];
   },
 
   removeArgs(name: string): string[] {
     return ['mcp', 'remove', '-s', 'user', name];
   },
 
-  parseGet(stdout: string, _name: string): RegisteredEntry | null {
-    if (!stdout || typeof stdout !== 'string') {
+  parseGet(stdout: string, name: string): RegisteredEntry | null {
+    if (!stdout || typeof stdout !== 'string') return null;
+
+    // `mcp list` line shape (stdio):
+    //   <name>: <command> [<arg> ...] - <status emoji + text>
+    // HTTP entries end with "(HTTP)" or start with http(s)://; we skip those.
+    const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const linePattern = new RegExp(`^${escaped}:\\s+(.+?)\\s+-\\s+`, 'm');
+
+    const match = stdout.match(linePattern);
+    if (!match) return null;
+
+    const cmdAndArgs = match[1].trim();
+    if (/\(HTTP\)$/.test(cmdAndArgs) || /^https?:\/\//.test(cmdAndArgs)) {
       return null;
     }
 
-    try {
-      const data = JSON.parse(stdout) as unknown;
+    const tokens = cmdAndArgs.split(/\s+/);
+    const command = tokens[0];
+    const args = tokens.slice(1);
 
-      // Validate shape: must have command field that is a string
-      if (
-        typeof data === 'object' &&
-        data !== null &&
-        'command' in data &&
-        typeof (data as Record<string, unknown>).command === 'string'
-      ) {
-        const parsed = data as Record<string, unknown>;
-        return {
-          command: parsed.command as string,
-          args: Array.isArray(parsed.args) ? parsed.args : [],
-          env:
-            typeof parsed.env === 'object' && parsed.env !== null
-              ? (parsed.env as Partial<GhostEnv>)
-              : {},
-        };
-      }
-
-      return null;
-    } catch {
-      // JSON.parse failed or any other error
-      return null;
-    }
+    // env is intentionally empty — Claude Code masks it. classify treats an
+    // empty registered env as "in-sync on env" so the wizard still detects
+    // command/args drift (the v1.0.x → npx migration case).
+    return { command, args, env: {} };
   },
 };

--- a/src/setup/clients/claude-code.ts
+++ b/src/setup/clients/claude-code.ts
@@ -1,0 +1,79 @@
+/**
+ * Claude Code MCP adapter — wraps `claude mcp add/list/get/remove`.
+ *
+ * @handbook 2.4-setup-wizard
+ */
+import { McpClient, RegisteredEntry, GhostEnv } from '../types.js';
+
+export const claudeCode: McpClient = {
+  id: 'claude-code',
+  label: 'Claude Code',
+  cli: 'claude',
+
+  addArgs(
+    name: string,
+    env: GhostEnv,
+    cmd: string,
+    cmdArgs: string[]
+  ): string[] {
+    return [
+      'mcp',
+      'add',
+      '-s',
+      'user',
+      '-e',
+      `GHOST_URL=${env.GHOST_URL}`,
+      '-e',
+      `GHOST_ADMIN_API_KEY=${env.GHOST_ADMIN_API_KEY}`,
+      name,
+      '--',
+      cmd,
+      ...cmdArgs,
+    ];
+  },
+
+  listArgs(): string[] {
+    return ['mcp', 'list'];
+  },
+
+  getArgs(name: string): string[] {
+    return ['mcp', 'get', name, '--json'];
+  },
+
+  removeArgs(name: string): string[] {
+    return ['mcp', 'remove', '-s', 'user', name];
+  },
+
+  parseGet(stdout: string, _name: string): RegisteredEntry | null {
+    if (!stdout || typeof stdout !== 'string') {
+      return null;
+    }
+
+    try {
+      const data = JSON.parse(stdout) as unknown;
+
+      // Validate shape: must have command field that is a string
+      if (
+        typeof data === 'object' &&
+        data !== null &&
+        'command' in data &&
+        typeof (data as Record<string, unknown>).command === 'string'
+      ) {
+        const parsed = data as Record<string, unknown>;
+        return {
+          command: parsed.command as string,
+          args: Array.isArray(parsed.args) ? parsed.args : [],
+          env:
+            typeof parsed.env === 'object' && parsed.env !== null
+              ? (parsed.env as Partial<GhostEnv>)
+              : {},
+        };
+      }
+
+      return null;
+    } catch {
+      // JSON.parse failed or any other error
+      return null;
+    }
+  },
+};

--- a/src/setup/clients/codex.test.ts
+++ b/src/setup/clients/codex.test.ts
@@ -1,0 +1,109 @@
+/** @covers src/setup/clients/codex.ts */
+import { describe, it, expect } from 'vitest';
+import { codex } from './codex.js';
+
+// Fixture mirrors real `codex mcp get xcodebuildmcp` output (captured 2025-05-27).
+const GET_FIXTURE = `xcodebuildmcp
+  enabled: true
+  transport: stdio
+  command: npx
+  args: -y xcodebuildmcp@latest mcp
+  cwd: -
+  env: XCODEBUILDMCP_ENABLED_WORKFLOWS=*****
+  remove: codex mcp remove xcodebuildmcp`;
+
+// Fixture with no args (e.g., command-only server)
+const GET_FIXTURE_NO_ARGS = `node_repl
+  enabled: true
+  transport: stdio
+  command: /Applications/Codex.app/Contents/Resources/node_repl
+  args: -
+  cwd: -
+  env: BROWSER_USE_AVAILABLE_BACKENDS=*****, CODEX_HOME=*****
+  remove: codex mcp remove node_repl`;
+
+describe('codex adapter', () => {
+  describe('addArgs', () => {
+    it('generates argv with --env long flags, -- separator, and no scope', () => {
+      const result = codex.addArgs(
+        'ghost-blog',
+        { GHOST_URL: 'https://blog.example.com', GHOST_ADMIN_API_KEY: 'id:secret' },
+        'npx',
+        ['-y', '@uppinote/ghost-mcp@latest']
+      );
+
+      expect(result).toEqual([
+        'mcp',
+        'add',
+        '--env',
+        'GHOST_URL=https://blog.example.com',
+        '--env',
+        'GHOST_ADMIN_API_KEY=id:secret',
+        'ghost-blog',
+        '--',
+        'npx',
+        '-y',
+        '@uppinote/ghost-mcp@latest',
+      ]);
+    });
+  });
+
+  describe('listArgs', () => {
+    it('returns mcp list argv', () => {
+      expect(codex.listArgs()).toEqual(['mcp', 'list']);
+    });
+  });
+
+  describe('getArgs', () => {
+    it('returns mcp get argv with the server name', () => {
+      expect(codex.getArgs('ghost-blog')).toEqual(['mcp', 'get', 'ghost-blog']);
+    });
+  });
+
+  describe('removeArgs', () => {
+    it('returns mcp remove argv (no scope, Codex stores globally)', () => {
+      expect(codex.removeArgs('ghost-blog')).toEqual(['mcp', 'remove', 'ghost-blog']);
+    });
+  });
+
+  describe('parseGet', () => {
+    it('extracts command and args from codex mcp get output', () => {
+      const result = codex.parseGet(GET_FIXTURE, 'xcodebuildmcp');
+      expect(result).toEqual({
+        command: 'npx',
+        args: ['-y', 'xcodebuildmcp@latest', 'mcp'],
+        env: {},
+      });
+    });
+
+    it('handles command-only server (args: -) by returning empty args array', () => {
+      const result = codex.parseGet(GET_FIXTURE_NO_ARGS, 'node_repl');
+      expect(result).toEqual({
+        command: '/Applications/Codex.app/Contents/Resources/node_repl',
+        args: [],
+        env: {},
+      });
+    });
+
+    it('always leaves env empty because Codex masks env values with *****', () => {
+      const result = codex.parseGet(GET_FIXTURE, 'xcodebuildmcp');
+      expect(result?.env).toEqual({});
+    });
+
+    it('returns null when the output is empty', () => {
+      expect(codex.parseGet('', 'xcodebuildmcp')).toBeNull();
+    });
+
+    it('returns null when the server is not found (Error: No MCP server...)', () => {
+      const errorOutput = "Error: No MCP server named 'not-registered' found.";
+      expect(codex.parseGet(errorOutput, 'not-registered')).toBeNull();
+    });
+
+    it('returns null when the command line is missing from the output', () => {
+      const malformedOutput = `xcodebuildmcp
+  enabled: true
+  transport: stdio`;
+      expect(codex.parseGet(malformedOutput, 'xcodebuildmcp')).toBeNull();
+    });
+  });
+});

--- a/src/setup/clients/codex.test.ts
+++ b/src/setup/clients/codex.test.ts
@@ -48,12 +48,6 @@ describe('codex adapter', () => {
     });
   });
 
-  describe('listArgs', () => {
-    it('returns mcp list argv', () => {
-      expect(codex.listArgs()).toEqual(['mcp', 'list']);
-    });
-  });
-
   describe('getArgs', () => {
     it('returns mcp get argv with the server name', () => {
       expect(codex.getArgs('ghost-blog')).toEqual(['mcp', 'get', 'ghost-blog']);

--- a/src/setup/clients/codex.ts
+++ b/src/setup/clients/codex.ts
@@ -8,7 +8,8 @@
  * the returned RegisteredEntry. classify.ts treats empty registered env as
  * "in-sync on env" so drift detection focuses on command/args.
  *
- * @handbook 2.4-setup-wizard
+ * @handbook 2.5-client-adapters
+ * @tested src/setup/clients/codex.test.ts
  */
 import { McpClient, RegisteredEntry, GhostEnv } from '../types.js';
 

--- a/src/setup/clients/codex.ts
+++ b/src/setup/clients/codex.ts
@@ -1,0 +1,93 @@
+/**
+ * Codex CLI MCP adapter — wraps `codex mcp add/list/get/remove`.
+ *
+ * Note: Codex stores MCP servers globally in ~/.codex/config.toml (no scope
+ * concept, unlike Claude Code which has user/workspace/workspace-user scopes).
+ * `codex mcp get <name>` returns structured output (enabled, command, args, env, etc.)
+ * with env values masked as *****. We parse the get output and leave env empty in
+ * the returned RegisteredEntry. classify.ts treats empty registered env as
+ * "in-sync on env" so drift detection focuses on command/args.
+ *
+ * @handbook 2.4-setup-wizard
+ */
+import { McpClient, RegisteredEntry, GhostEnv } from '../types.js';
+
+export const codex: McpClient = {
+  id: 'codex',
+  label: 'Codex',
+  cli: 'codex',
+
+  addArgs(
+    name: string,
+    env: GhostEnv,
+    cmd: string,
+    cmdArgs: string[]
+  ): string[] {
+    return [
+      'mcp',
+      'add',
+      '--env',
+      `GHOST_URL=${env.GHOST_URL}`,
+      '--env',
+      `GHOST_ADMIN_API_KEY=${env.GHOST_ADMIN_API_KEY}`,
+      name,
+      '--',
+      cmd,
+      ...cmdArgs,
+    ];
+  },
+
+  listArgs(): string[] {
+    return ['mcp', 'list'];
+  },
+
+  getArgs(name: string): string[] {
+    return ['mcp', 'get', name];
+  },
+
+  removeArgs(name: string): string[] {
+    return ['mcp', 'remove', name];
+  },
+
+  parseGet(stdout: string, name: string): RegisteredEntry | null {
+    if (!stdout) return null;
+
+    // If the server is not found, codex returns:
+    //   Error: No MCP server named '<name>' found.
+    if (stdout.includes('Error: No MCP server named')) {
+      return null;
+    }
+
+    // Parse `codex mcp get <name>` output format:
+    //   <name>
+    //     enabled: <bool>
+    //     transport: <type>
+    //     command: <path-or-binary>
+    //     args: <space-separated-args-or-dash>
+    //     cwd: <path-or-dash>
+    //     env: <comma-separated-KEY=VALUE-pairs-with-masked-values>
+    //     remove: <command>
+
+    // Extract the command line
+    const commandMatch = stdout.match(/^\s+command:\s+(.+?)$/m);
+    if (!commandMatch) return null;
+    const command = commandMatch[1].trim();
+
+    // Extract the args line
+    const argsMatch = stdout.match(/^\s+args:\s+(.+?)$/m);
+    if (!argsMatch) return null;
+    const argsStr = argsMatch[1].trim();
+
+    // If args is "-", treat as no args
+    let args: string[] = [];
+    if (argsStr !== '-') {
+      // Split by spaces (args is space-separated in a single line)
+      args = argsStr.split(/\s+/);
+    }
+
+    // env is intentionally empty — Codex masks values with *****. classify treats
+    // empty registered env as "in-sync on env" so drift detection focuses on
+    // command/args.
+    return { command, args, env: {} };
+  },
+};

--- a/src/setup/clients/codex.ts
+++ b/src/setup/clients/codex.ts
@@ -78,7 +78,9 @@ export const codex: McpClient = {
     // If args is "-", treat as no args
     let args: string[] = [];
     if (argsStr !== '-') {
-      // Split by spaces (args is space-separated in a single line)
+      // Split on whitespace. NOTE: mangles any arg containing a space (e.g. a
+      // path like "/my docs/server.js"). Safe for the canonical
+      // `-y @uppinote/ghost-mcp@latest`; revisit if codex's output format changes.
       args = argsStr.split(/\s+/);
     }
 

--- a/src/setup/clients/codex.ts
+++ b/src/setup/clients/codex.ts
@@ -37,10 +37,6 @@ export const codex: McpClient = {
     ];
   },
 
-  listArgs(): string[] {
-    return ['mcp', 'list'];
-  },
-
   getArgs(name: string): string[] {
     return ['mcp', 'get', name];
   },

--- a/src/setup/clients/gemini.test.ts
+++ b/src/setup/clients/gemini.test.ts
@@ -41,12 +41,6 @@ describe('gemini adapter', () => {
     });
   });
 
-  describe('listArgs', () => {
-    it('returns mcp list argv', () => {
-      expect(gemini.listArgs()).toEqual(['mcp', 'list']);
-    });
-  });
-
   describe('getArgs', () => {
     it('delegates to mcp list because Gemini has no mcp get subcommand', () => {
       expect(gemini.getArgs('ghost-blog')).toEqual(['mcp', 'list']);

--- a/src/setup/clients/gemini.test.ts
+++ b/src/setup/clients/gemini.test.ts
@@ -1,0 +1,87 @@
+/** @covers src/setup/clients/gemini.ts */
+import { describe, it, expect } from 'vitest';
+import { gemini } from './gemini.js';
+
+// Fixture: captured live from `gemini mcp list` output
+// Will fill in after live capture in Step 5
+const LIST_FIXTURE = `Registered MCP Servers:
+
+ghost-blog: npx -y @uppinote/ghost-mcp@latest - ✓ Connected
+context7: npx -y @upstash/context7-mcp - ✓ Connected
+`;
+
+describe('gemini adapter', () => {
+  describe('addArgs', () => {
+    it('generates argv with -s user scope, -e short env flags, and positional args (no -- separator)', () => {
+      const result = gemini.addArgs(
+        'ghost-blog',
+        { GHOST_URL: 'https://blog.example.com', GHOST_ADMIN_API_KEY: 'id:secret' },
+        'npx',
+        ['-y', '@uppinote/ghost-mcp@latest']
+      );
+
+      expect(result).toEqual([
+        'mcp',
+        'add',
+        '-s',
+        'user',
+        '-e',
+        'GHOST_URL=https://blog.example.com',
+        '-e',
+        'GHOST_ADMIN_API_KEY=id:secret',
+        'ghost-blog',
+        'npx',
+        '-y',
+        '@uppinote/ghost-mcp@latest',
+      ]);
+    });
+  });
+
+  describe('listArgs', () => {
+    it('returns mcp list argv', () => {
+      expect(gemini.listArgs()).toEqual(['mcp', 'list']);
+    });
+  });
+
+  describe('getArgs', () => {
+    it('delegates to mcp list because Gemini has no mcp get subcommand', () => {
+      expect(gemini.getArgs('ghost-blog')).toEqual(['mcp', 'list']);
+    });
+  });
+
+  describe('removeArgs', () => {
+    it('uses explicit -s user scope to match the scope used in add', () => {
+      expect(gemini.removeArgs('ghost-blog')).toEqual([
+        'mcp',
+        'remove',
+        '-s',
+        'user',
+        'ghost-blog',
+      ]);
+    });
+  });
+
+  describe('parseGet', () => {
+    it('extracts command and args for the target name from list output', () => {
+      const result = gemini.parseGet(LIST_FIXTURE, 'ghost-blog');
+      expect(result).toEqual({
+        command: 'npx',
+        args: ['-y', '@uppinote/ghost-mcp@latest'],
+        env: {},
+      });
+    });
+
+    it('always leaves env empty because Gemini masks env in list output', () => {
+      const result = gemini.parseGet(LIST_FIXTURE, 'ghost-blog');
+      expect(result?.env).toEqual({});
+    });
+
+    it('returns null when the target name is absent from the list', () => {
+      expect(gemini.parseGet(LIST_FIXTURE, 'not-registered')).toBeNull();
+    });
+
+    it('returns null for empty stdout', () => {
+      expect(gemini.parseGet('', 'ghost-blog')).toBeNull();
+    });
+  });
+});

--- a/src/setup/clients/gemini.test.ts
+++ b/src/setup/clients/gemini.test.ts
@@ -2,8 +2,12 @@
 import { describe, it, expect } from 'vitest';
 import { gemini } from './gemini.js';
 
-// Fixture: captured live from `gemini mcp list` output
-// Will fill in after live capture in Step 5
+// IMPORTANT — fixture is INFERRED-shape (Claude Code-style
+// `<name>: <cmd> - <status>`), NOT captured from a real `gemini mcp list`.
+// Live attempts on Gemini CLI v0.38.0 produced empty stdout even after
+// `mcp add`, so we cannot lock the real format yet. Tests below confirm the
+// parser works against the inferred shape (the contract); the first time a
+// real output is observed, update this fixture and re-run the suite.
 const LIST_FIXTURE = `Registered MCP Servers:
 
 ghost-blog: npx -y @uppinote/ghost-mcp@latest - ✓ Connected

--- a/src/setup/clients/gemini.test.ts
+++ b/src/setup/clients/gemini.test.ts
@@ -1,18 +1,9 @@
 /** @covers src/setup/clients/gemini.ts */
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import fs from 'node:fs';
 import { gemini } from './gemini.js';
 
-// IMPORTANT — fixture is INFERRED-shape (Claude Code-style
-// `<name>: <cmd> - <status>`), NOT captured from a real `gemini mcp list`.
-// Live attempts on Gemini CLI v0.38.0 produced empty stdout even after
-// `mcp add`, so we cannot lock the real format yet. Tests below confirm the
-// parser works against the inferred shape (the contract); the first time a
-// real output is observed, update this fixture and re-run the suite.
-const LIST_FIXTURE = `Registered MCP Servers:
-
-ghost-blog: npx -y @uppinote/ghost-mcp@latest - ✓ Connected
-context7: npx -y @upstash/context7-mcp - ✓ Connected
-`;
+afterEach(() => vi.restoreAllMocks());
 
 describe('gemini adapter', () => {
   describe('addArgs', () => {
@@ -25,61 +16,40 @@ describe('gemini adapter', () => {
       );
 
       expect(result).toEqual([
-        'mcp',
-        'add',
-        '-s',
-        'user',
-        '-e',
-        'GHOST_URL=https://blog.example.com',
-        '-e',
-        'GHOST_ADMIN_API_KEY=id:secret',
+        'mcp', 'add',
+        '-s', 'user',
+        '-e', 'GHOST_URL=https://blog.example.com',
+        '-e', 'GHOST_ADMIN_API_KEY=id:secret',
         'ghost-blog',
-        'npx',
-        '-y',
-        '@uppinote/ghost-mcp@latest',
+        'npx', '-y', '@uppinote/ghost-mcp@latest',
       ]);
-    });
-  });
-
-  describe('getArgs', () => {
-    it('delegates to mcp list because Gemini has no mcp get subcommand', () => {
-      expect(gemini.getArgs('ghost-blog')).toEqual(['mcp', 'list']);
     });
   });
 
   describe('removeArgs', () => {
     it('uses explicit -s user scope to match the scope used in add', () => {
       expect(gemini.removeArgs('ghost-blog')).toEqual([
-        'mcp',
-        'remove',
-        '-s',
-        'user',
-        'ghost-blog',
+        'mcp', 'remove', '-s', 'user', 'ghost-blog',
       ]);
     });
   });
 
-  describe('parseGet', () => {
-    it('extracts command and args for the target name from list output', () => {
-      const result = gemini.parseGet(LIST_FIXTURE, 'ghost-blog');
-      expect(result).toEqual({
+  // Edge cases (missing/malformed/absent) live in json-config.test.ts; here we
+  // just confirm gemini wires the right settings-file path.
+  describe('readEntry', () => {
+    it('reads ~/.gemini/settings.json for the target server', () => {
+      const spy = vi.spyOn(fs, 'readFileSync').mockReturnValue(
+        JSON.stringify({
+          mcpServers: { 'ghost-blog': { command: 'npx', args: ['-y', '@uppinote/ghost-mcp@latest'] } },
+        })
+      );
+
+      expect(gemini.readEntry!('ghost-blog')).toEqual({
         command: 'npx',
         args: ['-y', '@uppinote/ghost-mcp@latest'],
         env: {},
       });
-    });
-
-    it('always leaves env empty because Gemini masks env in list output', () => {
-      const result = gemini.parseGet(LIST_FIXTURE, 'ghost-blog');
-      expect(result?.env).toEqual({});
-    });
-
-    it('returns null when the target name is absent from the list', () => {
-      expect(gemini.parseGet(LIST_FIXTURE, 'not-registered')).toBeNull();
-    });
-
-    it('returns null for empty stdout', () => {
-      expect(gemini.parseGet('', 'ghost-blog')).toBeNull();
+      expect(String(spy.mock.calls[0]?.[0])).toMatch(/\.gemini[/\\]settings\.json$/);
     });
   });
 });

--- a/src/setup/clients/gemini.ts
+++ b/src/setup/clients/gemini.ts
@@ -1,0 +1,78 @@
+/**
+ * Gemini CLI MCP adapter — wraps `gemini mcp add/list/remove`.
+ *
+ * Notes:
+ * - Gemini has no `mcp get` subcommand, so getArgs delegates to `mcp list` and
+ *   parseGet filters by name.
+ * - `mcp add` requires `-s user` for global scope (default is 'project').
+ * - `mcp add` uses positional args (no `--` separator), unlike Claude Code / Codex.
+ * - env is returned as `{}` to match the Claude Code and Codex adapter design.
+ *
+ * @handbook 2.4-setup-wizard
+ */
+import { McpClient, RegisteredEntry, GhostEnv } from '../types.js';
+
+export const gemini: McpClient = {
+  id: 'gemini',
+  label: 'Gemini',
+  cli: 'gemini',
+
+  addArgs(
+    name: string,
+    env: GhostEnv,
+    cmd: string,
+    cmdArgs: string[]
+  ): string[] {
+    return [
+      'mcp',
+      'add',
+      '-s',
+      'user',
+      '-e',
+      `GHOST_URL=${env.GHOST_URL}`,
+      '-e',
+      `GHOST_ADMIN_API_KEY=${env.GHOST_ADMIN_API_KEY}`,
+      name,
+      cmd,
+      ...cmdArgs,
+    ];
+  },
+
+  listArgs(): string[] {
+    return ['mcp', 'list'];
+  },
+
+  // Delegates to `mcp list` and then filters by name in parseGet.
+  // Gemini has no `mcp get` subcommand.
+  getArgs(_name: string): string[] {
+    return ['mcp', 'list'];
+  },
+
+  removeArgs(name: string): string[] {
+    return ['mcp', 'remove', '-s', 'user', name];
+  },
+
+  parseGet(stdout: string, name: string): RegisteredEntry | null {
+    if (!stdout) return null;
+
+    // `mcp list` line shape (stdio):
+    //   <name>: <command> [<arg> ...] - <status emoji + text>
+    // We escape the name for regex safety and look for the target line.
+    const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const linePattern = new RegExp(`^${escaped}:\\s+(.+?)\\s+-\\s+`, 'm');
+
+    const match = stdout.match(linePattern);
+    if (!match) return null;
+
+    const cmdAndArgs = match[1].trim();
+    const tokens = cmdAndArgs.split(/\s+/);
+    const command = tokens[0];
+    if (!command) return null;
+    const args = tokens.slice(1);
+
+    // env is intentionally empty — Gemini masks it. classify treats an
+    // empty registered env as "in-sync on env" so the wizard still detects
+    // command/args drift.
+    return { command, args, env: {} };
+  },
+};

--- a/src/setup/clients/gemini.ts
+++ b/src/setup/clients/gemini.ts
@@ -1,27 +1,27 @@
 /**
- * Gemini CLI MCP adapter — wraps `gemini mcp add/list/remove`.
+ * Gemini CLI MCP adapter — writes via `gemini mcp add/remove`, but reads
+ * registration state from `~/.gemini/settings.json` directly.
  *
  * Notes:
- * - Gemini has no `mcp get` subcommand, so getArgs delegates to `mcp list` and
- *   parseGet filters by name.
  * - `mcp add` requires `-s user` for global scope (default is 'project').
  *   removeArgs also passes `-s user` so we delete from the same scope add wrote
  *   to (otherwise Gemini falls back to the default `project` scope and fails).
  * - `mcp add` uses positional args (no `--` separator), unlike Claude Code / Codex.
- * - env is returned as `{}` to match the Claude Code and Codex adapter design.
  *
- * IMPORTANT — list output format is INFERRED, not live-verified.
- * Gemini CLI v0.38.0 (the version available at implementation time) produces
- * empty stdout for `gemini mcp list` even after `mcp add` has populated
- * `~/.gemini/settings.json`. The parser below assumes the Claude Code line
- * shape (`<name>: <cmd> [<args>] - <status>`); if the real format diverges,
- * `parseGet` returns null and the wizard classifies the server as `missing`,
- * which triggers a benign re-registration on the next setup run. Update the
- * fixture and parser the first time we see real output.
+ * READ is file-based, not CLI-based. `gemini mcp list` (verified on v0.38.0) is
+ * TTY-gated: it prints the server table only when stdout is a TTY and emits
+ * *nothing* (0 bytes) when stdout is captured — which is exactly how the wizard
+ * reads it (a captured pipe, not a TTY). There is no --json flag to force
+ * machine-readable output, so the CLI is unusable for reads. readEntry parses
+ * the user-scope settings file instead — the same file `gemini mcp add -s user`
+ * writes to. Writes still go through the CLI (`mcp add` is not TTY-gated).
  *
  * @handbook 2.5-client-adapters
  * @tested src/setup/clients/gemini.test.ts
  */
+import os from 'node:os';
+import path from 'node:path';
+import { readFromJsonConfig } from './json-config.js';
 import { McpClient, RegisteredEntry, GhostEnv } from '../types.js';
 
 export const gemini: McpClient = {
@@ -50,37 +50,13 @@ export const gemini: McpClient = {
     ];
   },
 
-  // Delegates to `mcp list` and then filters by name in parseGet.
-  // Gemini has no `mcp get` subcommand.
-  getArgs(_name: string): string[] {
-    return ['mcp', 'list'];
-  },
-
   removeArgs(name: string): string[] {
     return ['mcp', 'remove', '-s', 'user', name];
   },
 
-  parseGet(stdout: string, name: string): RegisteredEntry | null {
-    if (!stdout) return null;
-
-    // `mcp list` line shape (stdio):
-    //   <name>: <command> [<arg> ...] - <status emoji + text>
-    // We escape the name for regex safety and look for the target line.
-    const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-    const linePattern = new RegExp(`^${escaped}:\\s+(.+?)\\s+-\\s+`, 'm');
-
-    const match = stdout.match(linePattern);
-    if (!match) return null;
-
-    const cmdAndArgs = match[1].trim();
-    const tokens = cmdAndArgs.split(/\s+/);
-    const command = tokens[0];
-    if (!command) return null;
-    const args = tokens.slice(1);
-
-    // env is intentionally empty — Gemini masks it. classify treats an
-    // empty registered env as "in-sync on env" so the wizard still detects
-    // command/args drift.
-    return { command, args, env: {} };
+  // Reads ~/.gemini/settings.json — see the file header for why `gemini mcp list`
+  // is unusable (TTY-gated when captured).
+  readEntry(name: string): RegisteredEntry | null {
+    return readFromJsonConfig(path.join(os.homedir(), '.gemini', 'settings.json'), name);
   },
 };

--- a/src/setup/clients/gemini.ts
+++ b/src/setup/clients/gemini.ts
@@ -5,8 +5,19 @@
  * - Gemini has no `mcp get` subcommand, so getArgs delegates to `mcp list` and
  *   parseGet filters by name.
  * - `mcp add` requires `-s user` for global scope (default is 'project').
+ *   removeArgs also passes `-s user` so we delete from the same scope add wrote
+ *   to (otherwise Gemini falls back to the default `project` scope and fails).
  * - `mcp add` uses positional args (no `--` separator), unlike Claude Code / Codex.
  * - env is returned as `{}` to match the Claude Code and Codex adapter design.
+ *
+ * IMPORTANT — list output format is INFERRED, not live-verified.
+ * Gemini CLI v0.38.0 (the version available at implementation time) produces
+ * empty stdout for `gemini mcp list` even after `mcp add` has populated
+ * `~/.gemini/settings.json`. The parser below assumes the Claude Code line
+ * shape (`<name>: <cmd> [<args>] - <status>`); if the real format diverges,
+ * `parseGet` returns null and the wizard classifies the server as `missing`,
+ * which triggers a benign re-registration on the next setup run. Update the
+ * fixture and parser the first time we see real output.
  *
  * @handbook 2.4-setup-wizard
  */

--- a/src/setup/clients/gemini.ts
+++ b/src/setup/clients/gemini.ts
@@ -19,7 +19,8 @@
  * which triggers a benign re-registration on the next setup run. Update the
  * fixture and parser the first time we see real output.
  *
- * @handbook 2.4-setup-wizard
+ * @handbook 2.5-client-adapters
+ * @tested src/setup/clients/gemini.test.ts
  */
 import { McpClient, RegisteredEntry, GhostEnv } from '../types.js';
 

--- a/src/setup/clients/gemini.ts
+++ b/src/setup/clients/gemini.ts
@@ -49,10 +49,6 @@ export const gemini: McpClient = {
     ];
   },
 
-  listArgs(): string[] {
-    return ['mcp', 'list'];
-  },
-
   // Delegates to `mcp list` and then filters by name in parseGet.
   // Gemini has no `mcp get` subcommand.
   getArgs(_name: string): string[] {

--- a/src/setup/clients/index.ts
+++ b/src/setup/clients/index.ts
@@ -1,0 +1,10 @@
+/**
+ * Registry of all MCP client adapters.
+ *
+ * @handbook 2.2-client-adapters
+ */
+import { claudeCode } from './claude-code.js';
+import { codex } from './codex.js';
+import { gemini } from './gemini.js';
+
+export const ALL_CLIENTS = [claudeCode, codex, gemini];

--- a/src/setup/clients/index.ts
+++ b/src/setup/clients/index.ts
@@ -1,7 +1,7 @@
 /**
  * Registry of all MCP client adapters.
  *
- * @handbook 2.2-client-adapters
+ * @handbook 2.5-client-adapters
  */
 import { claudeCode } from './claude-code.js';
 import { codex } from './codex.js';

--- a/src/setup/clients/json-config.test.ts
+++ b/src/setup/clients/json-config.test.ts
@@ -1,0 +1,57 @@
+/** @covers src/setup/clients/json-config.ts */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import fs from 'node:fs';
+import { readFromJsonConfig } from './json-config.js';
+
+afterEach(() => vi.restoreAllMocks());
+
+describe('readFromJsonConfig', () => {
+  it('extracts command and args for the target server, env left empty', () => {
+    vi.spyOn(fs, 'readFileSync').mockReturnValue(
+      JSON.stringify({
+        mcpServers: {
+          'ghost-blog': {
+            command: 'npx',
+            args: ['-y', '@uppinote/ghost-mcp@latest'],
+            env: { GHOST_URL: 'https://blog.example.com', GHOST_ADMIN_API_KEY: 'id:secret' },
+          },
+        },
+      })
+    );
+    expect(readFromJsonConfig('/cfg.json', 'ghost-blog')).toEqual({
+      command: 'npx',
+      args: ['-y', '@uppinote/ghost-mcp@latest'],
+      env: {},
+    });
+  });
+
+  it('returns null when the server is absent from the file', () => {
+    vi.spyOn(fs, 'readFileSync').mockReturnValue(
+      JSON.stringify({ mcpServers: { other: { command: 'node', args: [] } } })
+    );
+    expect(readFromJsonConfig('/cfg.json', 'ghost-blog')).toBeNull();
+  });
+
+  it('returns null when the file is missing', () => {
+    vi.spyOn(fs, 'readFileSync').mockImplementation(() => {
+      throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+    });
+    expect(readFromJsonConfig('/cfg.json', 'ghost-blog')).toBeNull();
+  });
+
+  it('returns null on malformed JSON', () => {
+    vi.spyOn(fs, 'readFileSync').mockReturnValue('{ not json');
+    expect(readFromJsonConfig('/cfg.json', 'ghost-blog')).toBeNull();
+  });
+
+  it('defaults args to [] when the entry omits them', () => {
+    vi.spyOn(fs, 'readFileSync').mockReturnValue(
+      JSON.stringify({ mcpServers: { 'ghost-blog': { command: 'npx' } } })
+    );
+    expect(readFromJsonConfig('/cfg.json', 'ghost-blog')).toEqual({
+      command: 'npx',
+      args: [],
+      env: {},
+    });
+  });
+});

--- a/src/setup/clients/json-config.ts
+++ b/src/setup/clients/json-config.ts
@@ -1,0 +1,31 @@
+/**
+ * Shared reader for adapters that read MCP registration from a JSON config file
+ * instead of the CLI — used when `mcp list` is unusable for a captured read.
+ * gemini's list is TTY-gated (empty when piped); claude's list reports the
+ * *effective* scope rather than the user scope the wizard writes to. env is left
+ * empty to match classify's env-skip convention (drift is detected on
+ * command/args).
+ *
+ * @handbook 2.5-client-adapters
+ * @tested src/setup/clients/json-config.test.ts
+ */
+import fs from 'node:fs';
+import { RegisteredEntry } from '../types.js';
+
+export function readFromJsonConfig(file: string, name: string): RegisteredEntry | null {
+  try {
+    const json = JSON.parse(fs.readFileSync(file, 'utf-8')) as {
+      mcpServers?: Record<string, { command?: unknown; args?: unknown }>;
+    };
+    const entry = json.mcpServers?.[name];
+    if (!entry || typeof entry.command !== 'string') return null;
+    return {
+      command: entry.command,
+      args: Array.isArray(entry.args) ? entry.args.map(String) : [],
+      env: {},
+    };
+  } catch {
+    // missing file / malformed JSON / no such server → treat as not registered
+    return null;
+  }
+}

--- a/src/setup/dispatch.test.ts
+++ b/src/setup/dispatch.test.ts
@@ -9,7 +9,6 @@ const mockClient: McpClient = {
   label: 'Test Client',
   cli: 'fake-cli',
   addArgs: (name, _env, cmd, args) => ['mcp', 'add', name, '--', cmd, ...args],
-  listArgs: () => ['mcp', 'list'],
   getArgs: (name) => ['mcp', 'get', name],
   removeArgs: (name) => ['mcp', 'remove', name],
   parseGet: (stdout) => (stdout ? { command: 'npx', args: [], env: {} } : null),

--- a/src/setup/dispatch.test.ts
+++ b/src/setup/dispatch.test.ts
@@ -1,0 +1,219 @@
+/** @covers src/setup/dispatch.ts */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { McpClient, GhostEnv } from './types.js';
+import * as proc from './process.js';
+import { detect, read, write, remove, SERVER_NAME, CANONICAL_CMD, CANONICAL_ARGS } from './dispatch.js';
+
+const mockClient: McpClient = {
+  id: 'test',
+  label: 'Test Client',
+  cli: 'fake-cli',
+  addArgs: (name, _env, cmd, args) => ['mcp', 'add', name, '--', cmd, ...args],
+  listArgs: () => ['mcp', 'list'],
+  getArgs: (name) => ['mcp', 'get', name],
+  removeArgs: (name) => ['mcp', 'remove', name],
+  parseGet: (stdout) => (stdout ? { command: 'npx', args: [], env: {} } : null),
+};
+
+const mockEnv: GhostEnv = {
+  GHOST_URL: 'https://test.ghost.io',
+  GHOST_ADMIN_API_KEY: 'test-key',
+};
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('dispatch', () => {
+  describe('detect', () => {
+    it('returns true when CLI returns status 0', () => {
+      const spy = vi.spyOn(proc, 'run').mockReturnValue({
+        status: 0,
+        stdout: '1.0.0',
+        stderr: '',
+      });
+
+      expect(detect(mockClient)).toBe(true);
+      expect(spy).toHaveBeenCalledWith('fake-cli', ['--version']);
+    });
+
+    it('returns false when CLI is missing (status null + error)', () => {
+      vi.spyOn(proc, 'run').mockReturnValue({
+        status: null,
+        stdout: '',
+        stderr: 'not found',
+      });
+
+      expect(detect(mockClient)).toBe(false);
+    });
+
+    it('returns false when CLI exits non-zero', () => {
+      vi.spyOn(proc, 'run').mockReturnValue({
+        status: 1,
+        stdout: '',
+        stderr: 'error',
+      });
+
+      expect(detect(mockClient)).toBe(false);
+    });
+  });
+
+  describe('read', () => {
+    it('delegates to client.parseGet on successful status', () => {
+      const stdout = 'test-content';
+      const parseGetSpy = vi.spyOn(mockClient, 'parseGet').mockReturnValue({
+        command: 'npx',
+        args: ['-y', '@uppinote/ghost-mcp@latest'],
+        env: {},
+      });
+
+      vi.spyOn(proc, 'run').mockReturnValue({
+        status: 0,
+        stdout,
+        stderr: '',
+      });
+
+      const result = read(mockClient);
+
+      expect(result).toEqual({
+        command: 'npx',
+        args: ['-y', '@uppinote/ghost-mcp@latest'],
+        env: {},
+      });
+      expect(parseGetSpy).toHaveBeenCalledWith(stdout, SERVER_NAME);
+    });
+
+    it('returns null when status non-zero and stdout empty', () => {
+      vi.spyOn(proc, 'run').mockReturnValue({
+        status: 1,
+        stdout: '',
+        stderr: 'error',
+      });
+
+      expect(read(mockClient)).toBeNull();
+    });
+
+    it('still calls parseGet when status non-zero but stdout non-empty', () => {
+      const stdout = 'error message with content';
+      const parseGetSpy = vi.spyOn(mockClient, 'parseGet').mockReturnValue(null);
+
+      vi.spyOn(proc, 'run').mockReturnValue({
+        status: 1,
+        stdout,
+        stderr: 'error',
+      });
+
+      read(mockClient);
+
+      expect(parseGetSpy).toHaveBeenCalledWith(stdout, SERVER_NAME);
+    });
+
+    it('uses custom name when provided', () => {
+      const getArgsSpy = vi.spyOn(mockClient, 'getArgs').mockReturnValue(['mcp', 'get', 'custom']);
+
+      vi.spyOn(proc, 'run').mockReturnValue({
+        status: 0,
+        stdout: '',
+        stderr: '',
+      });
+
+      read(mockClient, 'custom');
+
+      expect(getArgsSpy).toHaveBeenCalledWith('custom');
+    });
+  });
+
+  describe('write', () => {
+    it('calls run with cli, addArgs, and stdio inherit', () => {
+      const addArgsSpy = vi.spyOn(mockClient, 'addArgs').mockReturnValue(['mcp', 'add', 'ghost-blog', '--', 'npx', '-y', '@uppinote/ghost-mcp@latest']);
+      const runSpy = vi.spyOn(proc, 'run').mockReturnValue({
+        status: 0,
+        stdout: '',
+        stderr: '',
+      });
+
+      write(mockClient, mockEnv);
+
+      expect(addArgsSpy).toHaveBeenCalledWith(SERVER_NAME, mockEnv, CANONICAL_CMD, CANONICAL_ARGS);
+      expect(runSpy).toHaveBeenCalledWith(
+        'fake-cli',
+        ['mcp', 'add', 'ghost-blog', '--', 'npx', '-y', '@uppinote/ghost-mcp@latest'],
+        { stdio: 'inherit' }
+      );
+    });
+
+    it('throws on non-zero status with failing argv in message', () => {
+      const args = ['mcp', 'add', 'ghost-blog', '--', 'npx'];
+      vi.spyOn(mockClient, 'addArgs').mockReturnValue(args);
+      vi.spyOn(proc, 'run').mockReturnValue({
+        status: 1,
+        stdout: '',
+        stderr: 'error',
+      });
+
+      expect(() => write(mockClient, mockEnv)).toThrow(
+        /fake-cli mcp add ghost-blog -- npx.*exited with status 1/
+      );
+    });
+
+    it('uses custom name when provided', () => {
+      const addArgsSpy = vi.spyOn(mockClient, 'addArgs').mockReturnValue(['mcp', 'add', 'custom', '--', 'npx']);
+      vi.spyOn(proc, 'run').mockReturnValue({
+        status: 0,
+        stdout: '',
+        stderr: '',
+      });
+
+      write(mockClient, mockEnv, 'custom');
+
+      expect(addArgsSpy).toHaveBeenCalledWith('custom', mockEnv, CANONICAL_CMD, CANONICAL_ARGS);
+    });
+  });
+
+  describe('remove', () => {
+    it('calls run with removeArgs and stdio inherit', () => {
+      const removeArgsSpy = vi.spyOn(mockClient, 'removeArgs').mockReturnValue(['mcp', 'remove', 'ghost-blog']);
+      const runSpy = vi.spyOn(proc, 'run').mockReturnValue({
+        status: 0,
+        stdout: '',
+        stderr: '',
+      });
+
+      remove(mockClient);
+
+      expect(removeArgsSpy).toHaveBeenCalledWith(SERVER_NAME);
+      expect(runSpy).toHaveBeenCalledWith(
+        'fake-cli',
+        ['mcp', 'remove', 'ghost-blog'],
+        { stdio: 'inherit' }
+      );
+    });
+
+    it('throws on non-zero status with failing argv in message', () => {
+      const args = ['mcp', 'remove', 'ghost-blog'];
+      vi.spyOn(mockClient, 'removeArgs').mockReturnValue(args);
+      vi.spyOn(proc, 'run').mockReturnValue({
+        status: 1,
+        stdout: '',
+        stderr: 'error',
+      });
+
+      expect(() => remove(mockClient)).toThrow(
+        /fake-cli mcp remove ghost-blog.*exited with status 1/
+      );
+    });
+
+    it('uses custom name when provided', () => {
+      const removeArgsSpy = vi.spyOn(mockClient, 'removeArgs').mockReturnValue(['mcp', 'remove', 'custom']);
+      vi.spyOn(proc, 'run').mockReturnValue({
+        status: 0,
+        stdout: '',
+        stderr: '',
+      });
+
+      remove(mockClient, 'custom');
+
+      expect(removeArgsSpy).toHaveBeenCalledWith('custom');
+    });
+  });
+});

--- a/src/setup/dispatch.test.ts
+++ b/src/setup/dispatch.test.ts
@@ -25,40 +25,40 @@ beforeEach(() => {
 
 describe('dispatch', () => {
   describe('detect', () => {
-    it('returns true when CLI returns status 0', () => {
-      const spy = vi.spyOn(proc, 'run').mockReturnValue({
+    it('returns true when CLI returns status 0', async () => {
+      const spy = vi.spyOn(proc, 'run').mockResolvedValue({
         status: 0,
         stdout: '1.0.0',
         stderr: '',
       });
 
-      expect(detect(mockClient)).toBe(true);
+      expect(await detect(mockClient)).toBe(true);
       expect(spy).toHaveBeenCalledWith('fake-cli', ['--version']);
     });
 
-    it('returns false when CLI is missing (status null + error)', () => {
-      vi.spyOn(proc, 'run').mockReturnValue({
+    it('returns false when CLI is missing (status null + error)', async () => {
+      vi.spyOn(proc, 'run').mockResolvedValue({
         status: null,
         stdout: '',
         stderr: 'not found',
       });
 
-      expect(detect(mockClient)).toBe(false);
+      expect(await detect(mockClient)).toBe(false);
     });
 
-    it('returns false when CLI exits non-zero', () => {
-      vi.spyOn(proc, 'run').mockReturnValue({
+    it('returns false when CLI exits non-zero', async () => {
+      vi.spyOn(proc, 'run').mockResolvedValue({
         status: 1,
         stdout: '',
         stderr: 'error',
       });
 
-      expect(detect(mockClient)).toBe(false);
+      expect(await detect(mockClient)).toBe(false);
     });
   });
 
   describe('read', () => {
-    it('delegates to client.parseGet on successful status', () => {
+    it('delegates to client.parseGet on successful status', async () => {
       const stdout = 'test-content';
       const parseGetSpy = vi.spyOn(mockClient, 'parseGet').mockReturnValue({
         command: 'npx',
@@ -66,13 +66,13 @@ describe('dispatch', () => {
         env: {},
       });
 
-      vi.spyOn(proc, 'run').mockReturnValue({
+      vi.spyOn(proc, 'run').mockResolvedValue({
         status: 0,
         stdout,
         stderr: '',
       });
 
-      const result = read(mockClient);
+      const result = await read(mockClient);
 
       expect(result).toEqual({
         command: 'npx',
@@ -82,56 +82,77 @@ describe('dispatch', () => {
       expect(parseGetSpy).toHaveBeenCalledWith(stdout, SERVER_NAME);
     });
 
-    it('returns null when status non-zero and stdout empty', () => {
-      vi.spyOn(proc, 'run').mockReturnValue({
+    it('returns null when status non-zero and stdout empty', async () => {
+      vi.spyOn(proc, 'run').mockResolvedValue({
         status: 1,
         stdout: '',
         stderr: 'error',
       });
 
-      expect(read(mockClient)).toBeNull();
+      expect(await read(mockClient)).toBeNull();
     });
 
-    it('still calls parseGet when status non-zero but stdout non-empty', () => {
+    it('still calls parseGet when status non-zero but stdout non-empty', async () => {
       const stdout = 'error message with content';
       const parseGetSpy = vi.spyOn(mockClient, 'parseGet').mockReturnValue(null);
 
-      vi.spyOn(proc, 'run').mockReturnValue({
+      vi.spyOn(proc, 'run').mockResolvedValue({
         status: 1,
         stdout,
         stderr: 'error',
       });
 
-      read(mockClient);
+      await read(mockClient);
 
       expect(parseGetSpy).toHaveBeenCalledWith(stdout, SERVER_NAME);
     });
 
-    it('uses custom name when provided', () => {
+    it('uses custom name when provided', async () => {
       const getArgsSpy = vi.spyOn(mockClient, 'getArgs').mockReturnValue(['mcp', 'get', 'custom']);
 
-      vi.spyOn(proc, 'run').mockReturnValue({
+      vi.spyOn(proc, 'run').mockResolvedValue({
         status: 0,
         stdout: '',
         stderr: '',
       });
 
-      read(mockClient, 'custom');
+      await read(mockClient, 'custom');
 
       expect(getArgsSpy).toHaveBeenCalledWith('custom');
+    });
+
+    it('prefers client.readEntry over the CLI when present (gemini path)', async () => {
+      const runSpy = vi.spyOn(proc, 'run');
+      const fileClient: McpClient = {
+        ...mockClient,
+        readEntry: () => ({
+          command: 'npx',
+          args: ['-y', '@uppinote/ghost-mcp@latest'],
+          env: {},
+        }),
+      };
+
+      const result = await read(fileClient);
+
+      expect(result).toEqual({
+        command: 'npx',
+        args: ['-y', '@uppinote/ghost-mcp@latest'],
+        env: {},
+      });
+      expect(runSpy).not.toHaveBeenCalled();
     });
   });
 
   describe('write', () => {
-    it('calls run with cli, addArgs, and stdio inherit', () => {
+    it('calls run with cli, addArgs, and stdio inherit', async () => {
       const addArgsSpy = vi.spyOn(mockClient, 'addArgs').mockReturnValue(['mcp', 'add', 'ghost-blog', '--', 'npx', '-y', '@uppinote/ghost-mcp@latest']);
-      const runSpy = vi.spyOn(proc, 'run').mockReturnValue({
+      const runSpy = vi.spyOn(proc, 'run').mockResolvedValue({
         status: 0,
         stdout: '',
         stderr: '',
       });
 
-      write(mockClient, mockEnv);
+      await write(mockClient, mockEnv);
 
       expect(addArgsSpy).toHaveBeenCalledWith(SERVER_NAME, mockEnv, CANONICAL_CMD, CANONICAL_ARGS);
       expect(runSpy).toHaveBeenCalledWith(
@@ -141,44 +162,68 @@ describe('dispatch', () => {
       );
     });
 
-    it('throws on non-zero status with failing argv in message', () => {
+    it('throws on non-zero status with failing argv in message', async () => {
       const args = ['mcp', 'add', 'ghost-blog', '--', 'npx'];
       vi.spyOn(mockClient, 'addArgs').mockReturnValue(args);
-      vi.spyOn(proc, 'run').mockReturnValue({
+      vi.spyOn(proc, 'run').mockResolvedValue({
         status: 1,
         stdout: '',
         stderr: 'error',
       });
 
-      expect(() => write(mockClient, mockEnv)).toThrow(
+      await expect(write(mockClient, mockEnv)).rejects.toThrow(
         /fake-cli mcp add ghost-blog -- npx.*exited with status 1/
       );
     });
 
-    it('uses custom name when provided', () => {
+    it('uses custom name when provided', async () => {
       const addArgsSpy = vi.spyOn(mockClient, 'addArgs').mockReturnValue(['mcp', 'add', 'custom', '--', 'npx']);
-      vi.spyOn(proc, 'run').mockReturnValue({
+      vi.spyOn(proc, 'run').mockResolvedValue({
         status: 0,
         stdout: '',
         stderr: '',
       });
 
-      write(mockClient, mockEnv, 'custom');
+      await write(mockClient, mockEnv, 'custom');
 
       expect(addArgsSpy).toHaveBeenCalledWith('custom', mockEnv, CANONICAL_CMD, CANONICAL_ARGS);
+    });
+
+    it('removes before adding when replace is set', async () => {
+      vi.spyOn(mockClient, 'addArgs').mockReturnValue(['mcp', 'add', 'ghost-blog']);
+      vi.spyOn(mockClient, 'removeArgs').mockReturnValue(['mcp', 'remove', 'ghost-blog']);
+      const runSpy = vi.spyOn(proc, 'run').mockResolvedValue({ status: 0, stdout: '', stderr: '' });
+
+      await write(mockClient, mockEnv, SERVER_NAME, { replace: true });
+
+      const argvs = runSpy.mock.calls.map(([, a]) => a);
+      const removeIdx = argvs.findIndex((a) => a[0] === 'mcp' && a[1] === 'remove');
+      const addIdx = argvs.findIndex((a) => a[0] === 'mcp' && a[1] === 'add');
+      expect(removeIdx).toBeGreaterThanOrEqual(0);
+      expect(addIdx).toBeGreaterThan(removeIdx);
+    });
+
+    it('does not remove when replace is unset', async () => {
+      vi.spyOn(mockClient, 'addArgs').mockReturnValue(['mcp', 'add', 'ghost-blog']);
+      const removeArgsSpy = vi.spyOn(mockClient, 'removeArgs');
+      vi.spyOn(proc, 'run').mockResolvedValue({ status: 0, stdout: '', stderr: '' });
+
+      await write(mockClient, mockEnv);
+
+      expect(removeArgsSpy).not.toHaveBeenCalled();
     });
   });
 
   describe('remove', () => {
-    it('calls run with removeArgs and stdio inherit', () => {
+    it('calls run with removeArgs and stdio inherit', async () => {
       const removeArgsSpy = vi.spyOn(mockClient, 'removeArgs').mockReturnValue(['mcp', 'remove', 'ghost-blog']);
-      const runSpy = vi.spyOn(proc, 'run').mockReturnValue({
+      const runSpy = vi.spyOn(proc, 'run').mockResolvedValue({
         status: 0,
         stdout: '',
         stderr: '',
       });
 
-      remove(mockClient);
+      await remove(mockClient);
 
       expect(removeArgsSpy).toHaveBeenCalledWith(SERVER_NAME);
       expect(runSpy).toHaveBeenCalledWith(
@@ -188,29 +233,29 @@ describe('dispatch', () => {
       );
     });
 
-    it('throws on non-zero status with failing argv in message', () => {
+    it('throws on non-zero status with failing argv in message', async () => {
       const args = ['mcp', 'remove', 'ghost-blog'];
       vi.spyOn(mockClient, 'removeArgs').mockReturnValue(args);
-      vi.spyOn(proc, 'run').mockReturnValue({
+      vi.spyOn(proc, 'run').mockResolvedValue({
         status: 1,
         stdout: '',
         stderr: 'error',
       });
 
-      expect(() => remove(mockClient)).toThrow(
+      await expect(remove(mockClient)).rejects.toThrow(
         /fake-cli mcp remove ghost-blog.*exited with status 1/
       );
     });
 
-    it('uses custom name when provided', () => {
+    it('uses custom name when provided', async () => {
       const removeArgsSpy = vi.spyOn(mockClient, 'removeArgs').mockReturnValue(['mcp', 'remove', 'custom']);
-      vi.spyOn(proc, 'run').mockReturnValue({
+      vi.spyOn(proc, 'run').mockResolvedValue({
         status: 0,
         stdout: '',
         stderr: '',
       });
 
-      remove(mockClient, 'custom');
+      await remove(mockClient, 'custom');
 
       expect(removeArgsSpy).toHaveBeenCalledWith('custom');
     });

--- a/src/setup/dispatch.ts
+++ b/src/setup/dispatch.ts
@@ -30,8 +30,13 @@ export function write(client: McpClient, env: GhostEnv, name: string = SERVER_NA
   const args = client.addArgs(name, env, CANONICAL_CMD, CANONICAL_ARGS);
   const r = run(client.cli, args, { stdio: 'inherit' });
   if (r.status !== 0) {
+    // Redact env values in the error message — addArgs embeds GHOST_ADMIN_API_KEY
+    // and we don't want the API key leaking into terminal logs / clipboard / paste.
+    const redactedArgs = args.map((a) =>
+      /^(GHOST_URL|GHOST_ADMIN_API_KEY)=/.test(a) ? a.split('=')[0] + '=<redacted>' : a
+    );
     throw new Error(
-      `${client.label}: \`${client.cli} ${args.join(' ')}\` exited with status ${r.status}`
+      `${client.label}: \`${client.cli} ${redactedArgs.join(' ')}\` exited with status ${r.status}`
     );
   }
 }

--- a/src/setup/dispatch.ts
+++ b/src/setup/dispatch.ts
@@ -6,7 +6,8 @@
  * write()  — call `<cli> mcp add` with the canonical npx invocation
  * remove() — call `<cli> mcp remove`
  *
- * @handbook 2.4-setup-wizard
+ * @handbook 2.5-client-adapters
+ * @tested src/setup/dispatch.test.ts
  */
 import { McpClient, RegisteredEntry, GhostEnv } from './types.js';
 import { run } from './process.js';

--- a/src/setup/dispatch.ts
+++ b/src/setup/dispatch.ts
@@ -16,20 +16,42 @@ export const SERVER_NAME = 'ghost-blog';
 export const CANONICAL_CMD = 'npx';
 export const CANONICAL_ARGS = ['-y', '@uppinote/ghost-mcp@latest'];
 
-export function detect(client: McpClient): boolean {
-  const r = run(client.cli, ['--version']);
+export async function detect(client: McpClient): Promise<boolean> {
+  const r = await run(client.cli, ['--version']);
   return r.status === 0;
 }
 
-export function read(client: McpClient, name: string = SERVER_NAME): RegisteredEntry | null {
-  const r = run(client.cli, client.getArgs(name));
+export async function read(
+  client: McpClient,
+  name: string = SERVER_NAME
+): Promise<RegisteredEntry | null> {
+  // Adapter-specific read (gemini reads its settings file — see gemini.ts).
+  if (client.readEntry) return client.readEntry(name);
+  // CLI-based read: run the list/get command and parse its stdout.
+  if (!client.getArgs || !client.parseGet) return null;
+  const r = await run(client.cli, client.getArgs(name));
   if (r.status !== 0 && !r.stdout) return null;
   return client.parseGet(r.stdout, name);
 }
 
-export function write(client: McpClient, env: GhostEnv, name: string = SERVER_NAME): void {
+export async function write(
+  client: McpClient,
+  env: GhostEnv,
+  name: string = SERVER_NAME,
+  opts: { replace?: boolean } = {}
+): Promise<void> {
+  // replace = an entry already exists but differs. Most CLIs' `mcp add` refuses
+  // to overwrite an existing name, so remove first. Best-effort: a stale entry
+  // in a different scope than we write is a no-op here, and the add still succeeds.
+  if (opts.replace) {
+    try {
+      await remove(client, name);
+    } catch {
+      // entry may live in another scope or already be gone — add handles it
+    }
+  }
   const args = client.addArgs(name, env, CANONICAL_CMD, CANONICAL_ARGS);
-  const r = run(client.cli, args, { stdio: 'inherit' });
+  const r = await run(client.cli, args, { stdio: 'inherit' });
   if (r.status !== 0) {
     // Redact env values in the error message — addArgs embeds GHOST_ADMIN_API_KEY
     // and we don't want the API key leaking into terminal logs / clipboard / paste.
@@ -42,9 +64,12 @@ export function write(client: McpClient, env: GhostEnv, name: string = SERVER_NA
   }
 }
 
-export function remove(client: McpClient, name: string = SERVER_NAME): void {
+export async function remove(
+  client: McpClient,
+  name: string = SERVER_NAME
+): Promise<void> {
   const args = client.removeArgs(name);
-  const r = run(client.cli, args, { stdio: 'inherit' });
+  const r = await run(client.cli, args, { stdio: 'inherit' });
   if (r.status !== 0) {
     throw new Error(
       `${client.label}: \`${client.cli} ${args.join(' ')}\` exited with status ${r.status}`

--- a/src/setup/dispatch.ts
+++ b/src/setup/dispatch.ts
@@ -1,0 +1,47 @@
+/**
+ * Adapter-independent orchestration over an McpClient.
+ *
+ * detect() — is the CLI binary present on PATH?
+ * read()   — fetch the current ghost-blog registration (null if missing)
+ * write()  — call `<cli> mcp add` with the canonical npx invocation
+ * remove() — call `<cli> mcp remove`
+ *
+ * @handbook 2.4-setup-wizard
+ */
+import { McpClient, RegisteredEntry, GhostEnv } from './types.js';
+import { run } from './process.js';
+
+export const SERVER_NAME = 'ghost-blog';
+export const CANONICAL_CMD = 'npx';
+export const CANONICAL_ARGS = ['-y', '@uppinote/ghost-mcp@latest'];
+
+export function detect(client: McpClient): boolean {
+  const r = run(client.cli, ['--version']);
+  return r.status === 0;
+}
+
+export function read(client: McpClient, name: string = SERVER_NAME): RegisteredEntry | null {
+  const r = run(client.cli, client.getArgs(name));
+  if (r.status !== 0 && !r.stdout) return null;
+  return client.parseGet(r.stdout, name);
+}
+
+export function write(client: McpClient, env: GhostEnv, name: string = SERVER_NAME): void {
+  const args = client.addArgs(name, env, CANONICAL_CMD, CANONICAL_ARGS);
+  const r = run(client.cli, args, { stdio: 'inherit' });
+  if (r.status !== 0) {
+    throw new Error(
+      `${client.label}: \`${client.cli} ${args.join(' ')}\` exited with status ${r.status}`
+    );
+  }
+}
+
+export function remove(client: McpClient, name: string = SERVER_NAME): void {
+  const args = client.removeArgs(name);
+  const r = run(client.cli, args, { stdio: 'inherit' });
+  if (r.status !== 0) {
+    throw new Error(
+      `${client.label}: \`${client.cli} ${args.join(' ')}\` exited with status ${r.status}`
+    );
+  }
+}

--- a/src/setup/process.test.ts
+++ b/src/setup/process.test.ts
@@ -1,0 +1,27 @@
+/** @covers src/setup/process.ts */
+import { describe, it, expect } from 'vitest';
+import { run } from './process.js';
+
+describe('process.run', () => {
+  it('successful command returns status 0 and captures stdout', () => {
+    const result = run('node', ['-e', 'process.stdout.write("hello")']);
+    expect(result.status).toBe(0);
+    expect(result.stdout).toBe('hello');
+    expect(result.stderr).toBe('');
+    expect(result.error).toBeUndefined();
+  });
+
+  it('failing command returns non-zero status and captures stderr', () => {
+    const result = run('node', ['-e', 'process.stderr.write("oops"); process.exit(2)']);
+    expect(result.status).toBe(2);
+    expect(result.stderr).toBe('oops');
+    expect(result.error).toBeUndefined();
+  });
+
+  it('missing binary returns status null with error property defined', () => {
+    const result = run('this-binary-does-not-exist-xyz', ['--version']);
+    expect(result.status).toBeNull();
+    expect(result.error).toBeDefined();
+    expect(result.error).toBeInstanceOf(Error);
+  });
+});

--- a/src/setup/process.test.ts
+++ b/src/setup/process.test.ts
@@ -3,23 +3,23 @@ import { describe, it, expect } from 'vitest';
 import { run } from './process.js';
 
 describe('process.run', () => {
-  it('successful command returns status 0 and captures stdout', () => {
-    const result = run('node', ['-e', 'process.stdout.write("hello")']);
+  it('successful command returns status 0 and captures stdout', async () => {
+    const result = await run('node', ['-e', 'process.stdout.write("hello")']);
     expect(result.status).toBe(0);
     expect(result.stdout).toBe('hello');
     expect(result.stderr).toBe('');
     expect(result.error).toBeUndefined();
   });
 
-  it('failing command returns non-zero status and captures stderr', () => {
-    const result = run('node', ['-e', 'process.stderr.write("oops"); process.exit(2)']);
+  it('failing command returns non-zero status and captures stderr', async () => {
+    const result = await run('node', ['-e', 'process.stderr.write("oops"); process.exit(2)']);
     expect(result.status).toBe(2);
     expect(result.stderr).toBe('oops');
     expect(result.error).toBeUndefined();
   });
 
-  it('missing binary returns status null with error property defined', () => {
-    const result = run('this-binary-does-not-exist-xyz', ['--version']);
+  it('missing binary returns status null with error property defined', async () => {
+    const result = await run('this-binary-does-not-exist-xyz', ['--version']);
     expect(result.status).toBeNull();
     expect(result.error).toBeDefined();
     expect(result.error).toBeInstanceOf(Error);

--- a/src/setup/process.ts
+++ b/src/setup/process.ts
@@ -33,31 +33,23 @@ export function run(
     ...options,
   };
 
-  try {
-    const result = spawnSync(cli, args, mergedOptions);
+  const result = spawnSync(cli, args, mergedOptions);
 
-    // spawnSync sets error when the command could not be spawned
-    if (result.error) {
-      return {
-        status: null,
-        stdout: '',
-        stderr: '',
-        error: result.error,
-      };
-    }
-
-    return {
-      status: result.status ?? 0,
-      stdout: typeof result.stdout === 'string' ? result.stdout : result.stdout?.toString() ?? '',
-      stderr: typeof result.stderr === 'string' ? result.stderr : result.stderr?.toString() ?? '',
-    };
-  } catch (err) {
-    // Defensive: shouldn't reach here with spawnSync, but handle just in case
+  // spawnSync sets `error` when the command could not be spawned (ENOENT etc).
+  // It does not throw, so an outer try/catch would be dead defensive code.
+  if (result.error) {
     return {
       status: null,
       stdout: '',
       stderr: '',
-      error: err instanceof Error ? err : new Error(String(err)),
+      error: result.error,
     };
   }
+
+  return {
+    // status is null on signal termination — preserve that, don't coerce to 0.
+    status: result.status,
+    stdout: typeof result.stdout === 'string' ? result.stdout : '',
+    stderr: typeof result.stderr === 'string' ? result.stderr : '',
+  };
 }

--- a/src/setup/process.ts
+++ b/src/setup/process.ts
@@ -1,13 +1,16 @@
 /**
- * Thin wrapper around Node's spawnSync for testability.
+ * Thin async wrapper around Node's child_process.spawn, for testability and to
+ * keep the event loop free.
  *
- * Tests stub this module via vi.spyOn(proc, 'run') to unit-test dispatch logic
- * without launching real processes.
+ * Async (not spawnSync) on purpose: the wizard's scan shows a live spinner while
+ * each CLI probe runs, and a synchronous spawn would block the event loop and
+ * freeze the animation. Tests stub this module via vi.spyOn(proc, 'run') to
+ * unit-test dispatch logic without launching real processes.
  *
  * @handbook 2.5-client-adapters
  * @tested src/setup/process.test.ts
  */
-import { spawnSync, SpawnSyncOptions } from 'node:child_process';
+import { spawn, SpawnOptions } from 'node:child_process';
 
 export type RunResult = {
   status: number | null;
@@ -17,40 +20,43 @@ export type RunResult = {
 };
 
 /**
- * Run a command synchronously and capture its output.
+ * Run a command and capture its output.
  *
  * @param cli Command to run (e.g., "node", "gh")
  * @param args Command arguments
- * @param options Optional spawnSync options; defaults to UTF-8 encoding
- * @returns Object with status, stdout, stderr, and optional error
+ * @param options Optional spawn options; default stdio is 'pipe' so stdout/stderr
+ *   are captured. With stdio: 'inherit' (writes) nothing is piped, so stdout/stderr
+ *   come back empty and only `status` is meaningful.
+ * @returns Promise of { status, stdout, stderr, and optional error }
  */
 export function run(
   cli: string,
   args: string[],
-  options?: SpawnSyncOptions
-): RunResult {
-  const mergedOptions: SpawnSyncOptions = {
-    encoding: 'utf-8',
-    ...options,
-  };
+  options?: SpawnOptions
+): Promise<RunResult> {
+  return new Promise((resolve) => {
+    const child = spawn(cli, args, options ?? {});
 
-  const result = spawnSync(cli, args, mergedOptions);
+    let stdout = '';
+    let stderr = '';
+    child.stdout?.setEncoding('utf-8');
+    child.stderr?.setEncoding('utf-8');
+    child.stdout?.on('data', (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr?.on('data', (chunk) => {
+      stderr += chunk;
+    });
 
-  // spawnSync sets `error` when the command could not be spawned (ENOENT etc).
-  // It does not throw, so an outer try/catch would be dead defensive code.
-  if (result.error) {
-    return {
-      status: null,
-      stdout: '',
-      stderr: '',
-      error: result.error,
-    };
-  }
+    // 'error' fires when the command could not be spawned (ENOENT etc.).
+    child.on('error', (error) => {
+      resolve({ status: null, stdout: '', stderr: '', error });
+    });
 
-  return {
+    // 'close' fires once the process has exited and its stdio is flushed.
     // status is null on signal termination — preserve that, don't coerce to 0.
-    status: result.status,
-    stdout: typeof result.stdout === 'string' ? result.stdout : '',
-    stderr: typeof result.stderr === 'string' ? result.stderr : '',
-  };
+    child.on('close', (status) => {
+      resolve({ status, stdout, stderr });
+    });
+  });
 }

--- a/src/setup/process.ts
+++ b/src/setup/process.ts
@@ -4,7 +4,8 @@
  * Tests stub this module via vi.spyOn(proc, 'run') to unit-test dispatch logic
  * without launching real processes.
  *
- * @handbook 2.4-setup-wizard
+ * @handbook 2.5-client-adapters
+ * @tested src/setup/process.test.ts
  */
 import { spawnSync, SpawnSyncOptions } from 'node:child_process';
 

--- a/src/setup/process.ts
+++ b/src/setup/process.ts
@@ -1,0 +1,63 @@
+/**
+ * Thin wrapper around Node's spawnSync for testability.
+ *
+ * Tests stub this module via vi.spyOn(proc, 'run') to unit-test dispatch logic
+ * without launching real processes.
+ *
+ * @handbook 2.4-setup-wizard
+ */
+import { spawnSync, SpawnSyncOptions } from 'node:child_process';
+
+export type RunResult = {
+  status: number | null;
+  stdout: string;
+  stderr: string;
+  error?: Error;
+};
+
+/**
+ * Run a command synchronously and capture its output.
+ *
+ * @param cli Command to run (e.g., "node", "gh")
+ * @param args Command arguments
+ * @param options Optional spawnSync options; defaults to UTF-8 encoding
+ * @returns Object with status, stdout, stderr, and optional error
+ */
+export function run(
+  cli: string,
+  args: string[],
+  options?: SpawnSyncOptions
+): RunResult {
+  const mergedOptions: SpawnSyncOptions = {
+    encoding: 'utf-8',
+    ...options,
+  };
+
+  try {
+    const result = spawnSync(cli, args, mergedOptions);
+
+    // spawnSync sets error when the command could not be spawned
+    if (result.error) {
+      return {
+        status: null,
+        stdout: '',
+        stderr: '',
+        error: result.error,
+      };
+    }
+
+    return {
+      status: result.status ?? 0,
+      stdout: typeof result.stdout === 'string' ? result.stdout : result.stdout?.toString() ?? '',
+      stderr: typeof result.stderr === 'string' ? result.stderr : result.stderr?.toString() ?? '',
+    };
+  } catch (err) {
+    // Defensive: shouldn't reach here with spawnSync, but handle just in case
+    return {
+      status: null,
+      stdout: '',
+      stderr: '',
+      error: err instanceof Error ? err : new Error(String(err)),
+    };
+  }
+}

--- a/src/setup/types.ts
+++ b/src/setup/types.ts
@@ -18,16 +18,13 @@ export type RegisteredEntry = {
 export type ClientState =
   | { kind: 'in-sync'; entry: RegisteredEntry }
   | { kind: 'stale'; entry: RegisteredEntry; reasons: string[] }
-  | { kind: 'missing' }
-  | { kind: 'absent' }
-  | { kind: 'unparseable'; stderr: string };
+  | { kind: 'missing' };
 
 export interface McpClient {
   id: 'claude-code' | 'codex' | 'gemini';
   label: string;
   cli: string;
   addArgs(name: string, env: GhostEnv, cmd: string, cmdArgs: string[]): string[];
-  listArgs(): string[];
   getArgs(name: string): string[];
   removeArgs(name: string): string[];
   parseGet(stdout: string, name: string): RegisteredEntry | null;

--- a/src/setup/types.ts
+++ b/src/setup/types.ts
@@ -25,7 +25,12 @@ export interface McpClient {
   label: string;
   cli: string;
   addArgs(name: string, env: GhostEnv, cmd: string, cmdArgs: string[]): string[];
-  getArgs(name: string): string[];
   removeArgs(name: string): string[];
-  parseGet(stdout: string, name: string): RegisteredEntry | null;
+  // Read path — most adapters expose it via the CLI (getArgs + parseGet); gemini
+  // overrides with readEntry because `gemini mcp list` is TTY-gated (emits nothing
+  // when its stdout is captured) and has no --json flag, so it reads its config
+  // file directly instead.
+  getArgs?(name: string): string[];
+  parseGet?(stdout: string, name: string): RegisteredEntry | null;
+  readEntry?(name: string): RegisteredEntry | null;
 }

--- a/src/setup/types.ts
+++ b/src/setup/types.ts
@@ -1,7 +1,7 @@
 /**
  * Shared types for the multi-client MCP setup adapter system.
  *
- * @handbook 2.4-setup-wizard
+ * @handbook 2.5-client-adapters
  */
 
 export type GhostEnv = {

--- a/src/setup/types.ts
+++ b/src/setup/types.ts
@@ -21,7 +21,7 @@ export type ClientState =
   | { kind: 'missing' };
 
 export interface McpClient {
-  id: 'claude-code' | 'codex' | 'gemini';
+  id: string; // stable selection key (Set membership); not dispatched on
   label: string;
   cli: string;
   addArgs(name: string, env: GhostEnv, cmd: string, cmdArgs: string[]): string[];

--- a/src/setup/types.ts
+++ b/src/setup/types.ts
@@ -1,0 +1,34 @@
+/**
+ * Shared types for the multi-client MCP setup adapter system.
+ *
+ * @handbook 2.4-setup-wizard
+ */
+
+export type GhostEnv = {
+  GHOST_URL: string;
+  GHOST_ADMIN_API_KEY: string;
+};
+
+export type RegisteredEntry = {
+  command: string;
+  args: string[];
+  env: Partial<GhostEnv>;
+};
+
+export type ClientState =
+  | { kind: 'in-sync'; entry: RegisteredEntry }
+  | { kind: 'stale'; entry: RegisteredEntry; reasons: string[] }
+  | { kind: 'missing' }
+  | { kind: 'absent' }
+  | { kind: 'unparseable'; stderr: string };
+
+export interface McpClient {
+  id: 'claude-code' | 'codex' | 'gemini';
+  label: string;
+  cli: string;
+  addArgs(name: string, env: GhostEnv, cmd: string, cmdArgs: string[]): string[];
+  listArgs(): string[];
+  getArgs(name: string): string[];
+  removeArgs(name: string): string[];
+  parseGet(stdout: string, name: string): RegisteredEntry | null;
+}


### PR DESCRIPTION
## Summary
- Rewrites `ghost-mcp setup` into a multi-client wizard that discovers every installed MCP CLI (Claude Code, Codex, Gemini), classifies each one's current `ghost-blog` registration (in-sync / stale / missing), and applies the canonical npx invocation via each CLI's own `mcp add` — no direct config-file writes.
- An `McpClient` adapter per CLI (arg builders + a read strategy) behind an adapter-independent `dispatch` layer; adding a client is one file + one registry entry.
- Reads come from whichever source is reliable per CLI: Codex via `mcp get`, Claude Code and Gemini via their user-scope config files (Gemini's `mcp list` is TTY-gated → empty when captured; Claude's `mcp list` reports effective scope, not the user scope the wizard writes).
- Async scan with a live per-client progress spinner; stale registrations migrate (remove → add) instead of failing with "already exists".

## Changes
**Wizard & adapters (`src/setup/`)**
- `setup.ts` — discover → classify → resolve canonical → multiselect → apply, with per-client progress.
- `clients/{claude-code,codex,gemini}.ts` adapters + `clients/json-config.ts` shared user-scope file reader.
- `dispatch.ts` — async `detect`/`read`/`write`/`remove`; `write({replace})` removes before add for stale entries.
- `classify.ts` — in-sync/stale/missing classification + canonical resolution across clients.
- `process.ts` — async `spawn` wrapper (keeps the event loop free so the scan spinner animates; the `vi.spyOn` test seam).

**Fixes found via real-CLI testing**
- Claude `mcp add`: `<name>` must precede the variadic `-e` flags, else it is swallowed as an env value.
- Claude/Gemini read-scope alignment via file reads, so the wizard recognizes what it wrote.

**Docs**
- Engineering handbook §2.4/§2.5 and CLAUDE.md updated for the adapter architecture.

## Usage
```
npx -y @uppinote/ghost-mcp@latest setup   # or: npm run setup (dev)
```
Scans installed CLIs, prompts for `GHOST_URL` + Admin API Key, registers the server across the clients you select. Flags: `--yes`, `--star`, `--force-star-prompt`.

## Test plan
- [x] `npm run build` (tsc clean)
- [x] `npm test` — 192 passing (15 files)
- [x] Real-CLI run: Claude Code / Codex / Gemini classify in-sync after registration
- [x] Stale `node` dev-clone migrates to npx without "already exists"
- [x] Gemini registration read correctly despite TTY-gated `mcp list`