### PR TITLE
chore(ci): bump checkout to v6 and setup-node to v5 (Node 24 runtime)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,7 +26,7 @@ jobs:
       actions: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "20"
           registry-url: "https://registry.npmjs.org"


### PR DESCRIPTION
## Summary
- GitHub Actions is deprecating the Node.js 20 action runtime (forced Node 24 from 2026-06-16, removed 2026-09-16). This clears the runner warning by bumping to the fixed-runtime majors.
- `actions/checkout@v4 → @v6` across all 4 workflows; `actions/setup-node@v4 → @v5` in `release.yml`.
- `anthropics/claude-code-action@v1` is unaffected and left as-is.

## Changes
- `.github/workflows/release.yml` — checkout v6, setup-node v5
- `.github/workflows/release-drafter.yml` — checkout v6
- `.github/workflows/claude-code-review.yml` — checkout v6
- `.github/workflows/claude.yml` — checkout v6

## Notes
- `release.yml`'s `node-version: "20"` is the **build/test** Node, separate from the action runtime — out of scope here.

## Test plan
- [x] No `actions/checkout@v4` or `actions/setup-node@v4` remain (grep clean).
- [ ] `Claude Code Review` runs on this PR (uses checkout@v6) — green check confirms the bump works.
- [ ] `Publish Release` is tag-triggered (`v*`), so it won't run on this PR; will exercise on next release tag.