### PR TITLE
feat: add ghost_update_tag tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Create, edit, publish, and sync blog posts directly from Claude Code, Cursor, or
 
 - **Posts** &mdash; list, get, create, update, delete, publish with newsletter
 - **Pages** &mdash; list, get, update
-- **Tags** &mdash; list, create, delete, analyze usage patterns
+- **Tags** &mdash; list, create, update, delete, analyze usage patterns
 - **Images** &mdash; upload local files to Ghost CDN
 - **Sync** &mdash; push local markdown files (`~/blog-drafts/`) to Ghost as drafts
 - **Newsletters** &mdash; list available newsletters for email publishing
@@ -143,6 +143,7 @@ npm test
 | `ghost_update_page` | Update page content and metadata |
 | `ghost_list_tags` | List all tags with post counts |
 | `ghost_create_tag` | Create a new tag |
+| `ghost_update_tag` | Update a tag's name, slug, or description by ID or slug |
 | `ghost_delete_tag` | Delete a tag by ID or slug |
 | `ghost_analyze_tags` | Find unused, low-use, and similar tags |
 | `ghost_push_local` | Push a local markdown file to Ghost as a draft |

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ npm test
 | `ghost_update_page` | Update page content and metadata |
 | `ghost_list_tags` | List all tags with post counts |
 | `ghost_create_tag` | Create a new tag |
-| `ghost_update_tag` | Update a tag's name, slug, or description by ID or slug |
+| `ghost_update_tag` | Update a tag's name, slug, description, or visibility by ID or slug |
 | `ghost_delete_tag` | Delete a tag by ID or slug |
 | `ghost_analyze_tags` | Find unused, low-use, and similar tags |
 | `ghost_push_local` | Push a local markdown file to Ghost as a draft |

--- a/src/ghost/client.test.ts
+++ b/src/ghost/client.test.ts
@@ -145,6 +145,44 @@ describe('GhostAdminApi', () => {
     });
   });
 
+  // ── Tag update ──
+
+  describe('updateTag', () => {
+    it('PUTs to tags/{id}/ with a tags-wrapped body and returns the updated tag', async () => {
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: () =>
+          Promise.resolve({
+            tags: [
+              { id: 'tagid', name: 'Renamed', slug: 'renamed', description: null },
+            ],
+          }),
+      });
+      vi.stubGlobal('fetch', fetchMock);
+
+      const result = await api.updateTag('tagid', {
+        name: 'Renamed',
+        slug: 'renamed',
+        updated_at: '2026-01-01T00:00:00.000Z',
+      });
+
+      const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+      expect(url).toContain('/ghost/api/admin/tags/tagid/');
+      expect(init.method).toBe('PUT');
+      expect(JSON.parse(init.body as string)).toEqual({
+        tags: [
+          {
+            name: 'Renamed',
+            slug: 'renamed',
+            updated_at: '2026-01-01T00:00:00.000Z',
+          },
+        ],
+      });
+      expect(result.slug).toBe('renamed');
+    });
+  });
+
   // ── Upload restrictions (uses real temp files to avoid ESM mock issues) ──
 
   describe('uploadImage', () => {

--- a/src/ghost/client.ts
+++ b/src/ghost/client.ts
@@ -269,7 +269,13 @@ export class GhostAdminApi {
 
   async updateTag(
     id: string,
-    data: { name?: string; slug?: string; description?: string; updated_at?: string }
+    data: {
+      name?: string;
+      slug?: string;
+      description?: string;
+      visibility?: 'public' | 'internal';
+      updated_at?: string;
+    }
   ): Promise<GhostTag> {
     const response = await this.request<{ tags: GhostTag[] }>(`tags/${id}/`, {
       method: 'PUT',

--- a/src/ghost/client.ts
+++ b/src/ghost/client.ts
@@ -267,6 +267,17 @@ export class GhostAdminApi {
     return response.tags[0];
   }
 
+  async updateTag(
+    id: string,
+    data: { name?: string; slug?: string; description?: string; updated_at?: string }
+  ): Promise<GhostTag> {
+    const response = await this.request<{ tags: GhostTag[] }>(`tags/${id}/`, {
+      method: 'PUT',
+      body: JSON.stringify({ tags: [data] }),
+    });
+    return response.tags[0];
+  }
+
   async deleteTag(id: string): Promise<void> {
     await this.request(`tags/${id}/`, { method: 'DELETE' });
   }

--- a/src/ghost/types.ts
+++ b/src/ghost/types.ts
@@ -45,6 +45,7 @@ export interface GhostTag {
   name: string;
   slug: string;
   description: string | null;
+  updated_at?: string;
   count?: { posts: number };
 }
 

--- a/src/ghost/types.ts
+++ b/src/ghost/types.ts
@@ -45,6 +45,7 @@ export interface GhostTag {
   name: string;
   slug: string;
   description: string | null;
+  visibility?: 'public' | 'internal';
   updated_at?: string;
   count?: { posts: number };
 }

--- a/src/tools/tag-tools.ts
+++ b/src/tools/tag-tools.ts
@@ -169,7 +169,12 @@ export function registerTagTools(server: McpServer, ghost: GhostAdminApi) {
           updated_at: tag.updated_at,
         });
       }
-      audit('update_tag', { id: found.id, name: tag.name, slug: tag.slug });
+      audit('update_tag', {
+        id: found.id,
+        name: tag.name,
+        slug: tag.slug,
+        visibility: tag.visibility,
+      });
 
       return {
         content: [

--- a/src/tools/tag-tools.ts
+++ b/src/tools/tag-tools.ts
@@ -86,7 +86,7 @@ export function registerTagTools(server: McpServer, ghost: GhostAdminApi) {
 
   server.tool(
     'ghost_update_tag',
-    'Update an existing Ghost tag (name, slug, and/or description), identified by ID or current slug',
+    'Update an existing Ghost tag (name, slug, description, and/or visibility), identified by ID or current slug',
     {
       id: ghostId.optional().describe('Tag ID to update'),
       slug: safeSlug
@@ -95,8 +95,14 @@ export function registerTagTools(server: McpServer, ghost: GhostAdminApi) {
       name: z.string().optional().describe('New tag name'),
       new_slug: safeSlug.optional().describe('New tag slug'),
       description: z.string().optional().describe('New tag description'),
+      visibility: z
+        .enum(['public', 'internal'])
+        .optional()
+        .describe(
+          'Tag visibility. "internal" hides it from public tag pages/search (Ghost\'s "#" convention). Ghost stores this separately from the name, so set it explicitly when converting an internal tag to public (or vice versa) — renaming alone will not change it.'
+        ),
     },
-    async ({ id, slug, name, new_slug, description }) => {
+    async ({ id, slug, name, new_slug, description, visibility }) => {
       if (!id && !slug) {
         return {
           content: [
@@ -106,7 +112,7 @@ export function registerTagTools(server: McpServer, ghost: GhostAdminApi) {
         };
       }
 
-      const hasAnyField = [name, new_slug, description].some(
+      const hasAnyField = [name, new_slug, description, visibility].some(
         (v) => v !== undefined
       );
       if (!hasAnyField) {
@@ -114,7 +120,7 @@ export function registerTagTools(server: McpServer, ghost: GhostAdminApi) {
           content: [
             {
               type: 'text' as const,
-              text: 'No fields provided to update (name, new_slug, or description).',
+              text: 'No fields provided to update (name, new_slug, description, or visibility).',
             },
           ],
           isError: true,
@@ -140,12 +146,29 @@ export function registerTagTools(server: McpServer, ghost: GhostAdminApi) {
         };
       }
 
-      const tag = await ghost.updateTag(found.id, {
+      // Display fields and visibility are sent as separate PUTs: Ghost drops
+      // visibility when it arrives alongside other fields (same quirk as posts —
+      // see ghost_update_post / handbook 5.2). Each PUT carries the latest
+      // updated_at for optimistic locking.
+      const displayFields = {
         ...(name !== undefined && { name }),
         ...(new_slug !== undefined && { slug: new_slug }),
         ...(description !== undefined && { description }),
-        updated_at: found.updated_at,
-      });
+      };
+
+      let tag = found;
+      if (Object.keys(displayFields).length > 0) {
+        tag = await ghost.updateTag(found.id, {
+          ...displayFields,
+          updated_at: found.updated_at,
+        });
+      }
+      if (visibility !== undefined) {
+        tag = await ghost.updateTag(found.id, {
+          visibility,
+          updated_at: tag.updated_at,
+        });
+      }
       audit('update_tag', { id: found.id, name: tag.name, slug: tag.slug });
 
       return {
@@ -160,6 +183,8 @@ export function registerTagTools(server: McpServer, ghost: GhostAdminApi) {
               `| ID | ${tag.id} |`,
               `| Name | ${tag.name} |`,
               `| Slug | ${tag.slug} |`,
+              `| Description | ${tag.description || '(none)'} |`,
+              `| Visibility | ${tag.visibility || 'public'} |`,
             ].join('\n'),
           },
         ],

--- a/src/tools/tag-tools.ts
+++ b/src/tools/tag-tools.ts
@@ -1,6 +1,8 @@
 /**
  * @tested src/tools/tools.test.ts
  * @handbook 5.1-zod-schema-and-formatter
+ * @handbook 5.2-optimistic-locking-split
+ * @handbook 5.3-empty-input-guard
  */
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
@@ -69,6 +71,89 @@ export function registerTagTools(server: McpServer, ghost: GhostAdminApi) {
             type: 'text' as const,
             text: [
               `Tag created!`,
+              '',
+              `| Field | Value |`,
+              `|-------|-------|`,
+              `| ID | ${tag.id} |`,
+              `| Name | ${tag.name} |`,
+              `| Slug | ${tag.slug} |`,
+            ].join('\n'),
+          },
+        ],
+      };
+    }
+  );
+
+  server.tool(
+    'ghost_update_tag',
+    'Update an existing Ghost tag (name, slug, and/or description), identified by ID or current slug',
+    {
+      id: ghostId.optional().describe('Tag ID to update'),
+      slug: safeSlug
+        .optional()
+        .describe('Current tag slug (looked up to find the ID)'),
+      name: z.string().optional().describe('New tag name'),
+      new_slug: safeSlug.optional().describe('New tag slug'),
+      description: z.string().optional().describe('New tag description'),
+    },
+    async ({ id, slug, name, new_slug, description }) => {
+      if (!id && !slug) {
+        return {
+          content: [
+            { type: 'text' as const, text: 'Either id or slug is required.' },
+          ],
+          isError: true,
+        };
+      }
+
+      const hasAnyField = [name, new_slug, description].some(
+        (v) => v !== undefined
+      );
+      if (!hasAnyField) {
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: 'No fields provided to update (name, new_slug, or description).',
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      // Fetch the current tag to resolve its ID (slug lookup, delete pattern)
+      // and capture updated_at for optimistic locking — mirrors
+      // ghost_update_post. getTags returns all tags including updated_at.
+      const { tags } = await ghost.getTags();
+      const found = id
+        ? tags.find((t) => t.id === id)
+        : tags.find((t) => t.slug === slug);
+      if (!found) {
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: `Tag not found with ${id ? `id: ${id}` : `slug: ${slug}`}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      const tag = await ghost.updateTag(found.id, {
+        ...(name !== undefined && { name }),
+        ...(new_slug !== undefined && { slug: new_slug }),
+        ...(description !== undefined && { description }),
+        updated_at: found.updated_at,
+      });
+      audit('update_tag', { id: found.id, name: tag.name, slug: tag.slug });
+
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: [
+              `Tag updated!`,
               '',
               `| Field | Value |`,
               `|-------|-------|`,

--- a/src/tools/tools.test.ts
+++ b/src/tools/tools.test.ts
@@ -64,6 +64,7 @@ function createMockGhost(overrides: Partial<{
     name: 'Tech',
     slug: 'tech',
     description: 'Technology posts',
+    updated_at: '2026-01-01T00:00:00.000Z',
     count: { posts: 5 },
   };
 
@@ -80,6 +81,7 @@ function createMockGhost(overrides: Partial<{
     updatePage: vi.fn().mockResolvedValue(mockPost),
     getTags: vi.fn().mockResolvedValue({ tags: [mockTag], pagination: undefined }),
     createTag: vi.fn().mockResolvedValue(mockTag),
+    updateTag: vi.fn().mockResolvedValue(mockTag),
     deleteTag: vi.fn().mockResolvedValue(undefined),
     getNewsletters: vi.fn().mockResolvedValue([]),
     uploadImage: vi.fn().mockResolvedValue('https://cdn.example.com/image.png'),
@@ -278,6 +280,104 @@ describe('Tag Tools (MCP integration)', () => {
       arguments: { slug: '../../evil', confirm: true },
     });
     expect(result.isError).toBe(true);
+  });
+});
+
+// ── Tag Tools — ghost_update_tag ─────────────────
+
+describe('ghost_update_tag (MCP integration)', () => {
+  let client: Client;
+  let ghost: GhostAdminApi;
+
+  beforeAll(async () => {
+    ghost = createMockGhost();
+    ({ client } = await setupMcpClient(ghost));
+  });
+
+  afterAll(async () => {
+    await client.close();
+  });
+
+  it('updates a tag by id, forwarding fields + updated_at for optimistic locking', async () => {
+    vi.clearAllMocks();
+    const result = await client.callTool({
+      name: 'ghost_update_tag',
+      arguments: {
+        id: '607f1f77bcf86cd799439022',
+        name: 'Technology',
+        new_slug: 'technology',
+      },
+    });
+    expect(result.isError).toBeFalsy();
+    expect(ghost.updateTag).toHaveBeenCalledWith(
+      '607f1f77bcf86cd799439022',
+      expect.objectContaining({
+        name: 'Technology',
+        slug: 'technology',
+        updated_at: '2026-01-01T00:00:00.000Z',
+      })
+    );
+    const text = (result.content as { type: string; text: string }[])[0].text;
+    expect(text).toContain('Tag updated');
+  });
+
+  it('resolves the tag id from the current slug before updating', async () => {
+    vi.clearAllMocks();
+    await client.callTool({
+      name: 'ghost_update_tag',
+      arguments: { slug: 'tech', description: 'Updated description' },
+    });
+    expect(ghost.getTags).toHaveBeenCalled();
+    expect(ghost.updateTag).toHaveBeenCalledWith(
+      '607f1f77bcf86cd799439022',
+      expect.objectContaining({ description: 'Updated description' })
+    );
+  });
+
+  it('returns error when neither id nor slug is provided', async () => {
+    vi.clearAllMocks();
+    const result = await client.callTool({
+      name: 'ghost_update_tag',
+      arguments: { name: 'Orphan' },
+    });
+    expect(result.isError).toBe(true);
+    expect(ghost.updateTag).not.toHaveBeenCalled();
+    const text = (result.content as { type: string; text: string }[])[0].text;
+    expect(text).toContain('Either id or slug');
+  });
+
+  it('returns error when no change fields are provided', async () => {
+    vi.clearAllMocks();
+    const result = await client.callTool({
+      name: 'ghost_update_tag',
+      arguments: { id: '607f1f77bcf86cd799439022' },
+    });
+    expect(result.isError).toBe(true);
+    expect(ghost.updateTag).not.toHaveBeenCalled();
+    const text = (result.content as { type: string; text: string }[])[0].text;
+    expect(text).toContain('No fields provided');
+  });
+
+  it('returns error when the slug lookup finds no tag', async () => {
+    vi.clearAllMocks();
+    const result = await client.callTool({
+      name: 'ghost_update_tag',
+      arguments: { slug: 'does-not-exist', name: 'X' },
+    });
+    expect(result.isError).toBe(true);
+    expect(ghost.updateTag).not.toHaveBeenCalled();
+    const text = (result.content as { type: string; text: string }[])[0].text;
+    expect(text).toContain('not found');
+  });
+
+  it('rejects an invalid id format (zod ghostId)', async () => {
+    vi.clearAllMocks();
+    const result = await client.callTool({
+      name: 'ghost_update_tag',
+      arguments: { id: '../traversal', name: 'X' },
+    });
+    expect(result.isError).toBe(true);
+    expect(ghost.updateTag).not.toHaveBeenCalled();
   });
 });
 

--- a/src/tools/tools.test.ts
+++ b/src/tools/tools.test.ts
@@ -64,6 +64,7 @@ function createMockGhost(overrides: Partial<{
     name: 'Tech',
     slug: 'tech',
     description: 'Technology posts',
+    visibility: 'public' as const,
     updated_at: '2026-01-01T00:00:00.000Z',
     count: { posts: 5 },
   };
@@ -331,6 +332,58 @@ describe('ghost_update_tag (MCP integration)', () => {
     expect(ghost.updateTag).toHaveBeenCalledWith(
       '607f1f77bcf86cd799439022',
       expect.objectContaining({ description: 'Updated description' })
+    );
+  });
+
+  it('sends visibility as its own PUT when no display fields change', async () => {
+    vi.clearAllMocks();
+    const result = await client.callTool({
+      name: 'ghost_update_tag',
+      arguments: { id: '607f1f77bcf86cd799439022', visibility: 'public' },
+    });
+    expect(result.isError).toBeFalsy();
+    expect(ghost.updateTag).toHaveBeenCalledTimes(1);
+    expect(ghost.updateTag).toHaveBeenCalledWith(
+      '607f1f77bcf86cd799439022',
+      expect.objectContaining({
+        visibility: 'public',
+        updated_at: '2026-01-01T00:00:00.000Z',
+      })
+    );
+  });
+
+  it('splits display fields and visibility into two separate PUTs', async () => {
+    vi.clearAllMocks();
+    await client.callTool({
+      name: 'ghost_update_tag',
+      arguments: {
+        id: '607f1f77bcf86cd799439022',
+        name: 'Renamed',
+        visibility: 'internal',
+      },
+    });
+    expect(ghost.updateTag).toHaveBeenCalledTimes(2);
+    // 1st PUT: display fields only (no visibility — Ghost would drop it)
+    expect(ghost.updateTag).toHaveBeenNthCalledWith(
+      1,
+      '607f1f77bcf86cd799439022',
+      expect.objectContaining({ name: 'Renamed' })
+    );
+    expect(ghost.updateTag).toHaveBeenNthCalledWith(
+      1,
+      '607f1f77bcf86cd799439022',
+      expect.not.objectContaining({ visibility: expect.anything() })
+    );
+    // 2nd PUT: visibility only
+    expect(ghost.updateTag).toHaveBeenNthCalledWith(
+      2,
+      '607f1f77bcf86cd799439022',
+      expect.objectContaining({ visibility: 'internal' })
+    );
+    expect(ghost.updateTag).toHaveBeenNthCalledWith(
+      2,
+      '607f1f77bcf86cd799439022',
+      expect.not.objectContaining({ name: expect.anything() })
     );
   });
 


### PR DESCRIPTION
## Summary

- Adds `ghost_update_tag` — update a tag's `name`, `slug`, and/or `description`, identified by **ID or current slug**. Fills the gap where tags could be listed/created/deleted/analyzed but never edited.
- `GhostAdminApi.updateTag()` follows the `ghost_update_post` optimistic-locking pattern: it fetches the current tag and sends `updated_at` in the `PUT /tags/{id}/` body so a stale edit can't silently clobber a newer one.
- Slug→id resolution reuses the `ghost_delete_tag` approach (`getTags` + find); the same fetch yields `updated_at`, so tags need only a single PUT (no visibility split — tags have no visibility).
- Empty-input guard + `audit('update_tag')` logging, consistent with the other mutating tools.

## Usage

```jsonc
// By current slug (the common case — rename + re-slug):
{ "name": "ghost_update_tag", "arguments": {
  "slug": "dogu-github",        // current slug, used to find the tag
  "name": "도구/GitHub",
  "new_slug": "tool-github"      // new slug
}}

// By ID, description only:
{ "name": "ghost_update_tag", "arguments": {
  "id": "607f1f77bcf86cd799439022",
  "description": "GitHub 관련 글"
}}
```

Errors (returned as `isError`) when: neither `id` nor `slug` is given, no change field is given, or the slug/id resolves to no tag.

## Test plan

- [x] `npm run build` — clean (tsc)
- [x] `npm test` — 200/200 pass
- [x] `client.test.ts`: `updateTag()` issues `PUT tags/{id}/` with a `{ tags: [data] }` body and returns the updated tag
- [x] `tools.test.ts`: 6 cases — update by id (forwards fields + `updated_at`), slug→id lookup, missing id/slug, no change fields, slug not found, invalid id format